### PR TITLE
feat: implement user profile facts structured storage

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -164,6 +164,51 @@ curl -X PUT http://localhost:8080/v1alpha1/memorix/<tenantID>/memories/<id> \
 curl -X DELETE http://localhost:8080/v1alpha1/memorix/<tenantID>/memories/<id>
 ```
 
+### User Profile Facts
+
+User profile facts are structured long-term facts about users, supporting precise CRUD operations without vector search. Each user can store up to 200 facts, with automatic cleanup of oldest low-confidence facts when capacity is reached.
+
+```bash
+# Create a fact
+curl -X POST http://localhost:8080/v1alpha1/memorix/<tenantID>/user-profile/facts \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_id": "user-123",
+    "category": "personal",
+    "key": "name",
+    "value": "John Doe",
+    "source": "explicit",
+    "confidence": 1.0
+  }'
+
+# List facts (filter by user_id required)
+curl "http://localhost:8080/v1alpha1/memorix/<tenantID>/user-profile/facts?user_id=user-123"
+
+# List facts by category
+curl "http://localhost:8080/v1alpha1/memorix/<tenantID>/user-profile/facts?user_id=user-123&category=preference"
+
+# Get a single fact
+curl "http://localhost:8080/v1alpha1/memorix/<tenantID>/user-profile/facts/<fact_id>"
+
+# Update a fact
+curl -X PUT http://localhost:8080/v1alpha1/memorix/<tenantID>/user-profile/facts/<fact_id> \
+  -H "Content-Type: application/json" \
+  -d '{"value": "Jane Doe"}'
+
+# Delete a fact
+curl -X DELETE http://localhost:8080/v1alpha1/memorix/<tenantID>/user-profile/facts/<fact_id>"
+```
+
+**Fact Categories:**
+- `personal` - Name, role, location, etc.
+- `preference` - Language, framework, style preferences
+- `goal` - User goals and objectives
+- `skill` - Known skills and expertise
+
+**Fact Sources:**
+- `explicit` - User explicitly provided (confidence typically 1.0)
+- `inferred` - Model inferred from conversation (confidence 0.0-1.0)
+
 ## Build
 
 ```bash

--- a/server/internal/domain/user_profile.go
+++ b/server/internal/domain/user_profile.go
@@ -1,0 +1,94 @@
+package domain
+
+import (
+	"time"
+)
+
+// FactCategory represents the category of a user profile fact.
+type FactCategory string
+
+const (
+	CategoryPersonal   FactCategory = "personal"
+	CategoryPreference FactCategory = "preference"
+	CategoryGoal       FactCategory = "goal"
+	CategorySkill      FactCategory = "skill"
+)
+
+// FactSource represents how a fact was obtained.
+type FactSource string
+
+const (
+	SourceExplicit FactSource = "explicit" // User explicitly provided
+	SourceInferred FactSource = "inferred" // Model inferred from conversation
+)
+
+// UserProfileFact represents a structured long-term fact about a user.
+// Based on ChatGPT's third-layer "user memory" design from reverse engineering analysis.
+type UserProfileFact struct {
+	FactID     string       `json:"fact_id"`
+	UserID     string       `json:"user_id"`
+	Category   FactCategory `json:"category"`
+	Key        string       `json:"key"`
+	Value      string       `json:"value"`
+	Source     FactSource   `json:"source"`
+	Confidence float64      `json:"confidence"` // 0-1, confidence level for inferred facts
+
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+	LastAccessedAt time.Time `json:"last_accessed_at"`
+}
+
+// UserProfileFactFilter encapsulates query parameters for fact queries.
+type UserProfileFactFilter struct {
+	UserID   string
+	Category FactCategory
+	Key      string
+	Source   FactSource
+	Limit    int
+	Offset   int
+}
+
+// ValidFactCategories returns all valid fact categories.
+func ValidFactCategories() []FactCategory {
+	return []FactCategory{
+		CategoryPersonal,
+		CategoryPreference,
+		CategoryGoal,
+		CategorySkill,
+	}
+}
+
+// IsValidCategory checks if a category is valid.
+func IsValidCategory(c FactCategory) bool {
+	for _, valid := range ValidFactCategories() {
+		if c == valid {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidFactSources returns all valid fact sources.
+func ValidFactSources() []FactSource {
+	return []FactSource{
+		SourceExplicit,
+		SourceInferred,
+	}
+}
+
+// IsValidSource checks if a source is valid.
+func IsValidSource(s FactSource) bool {
+	for _, valid := range ValidFactSources() {
+		if s == valid {
+			return true
+		}
+	}
+	return false
+}
+
+// Default capacity limits
+const (
+	DefaultMaxFactsPerUser = 200
+	MinConfidence          = 0.0
+	MaxConfidence          = 1.0
+)

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -38,6 +38,9 @@ type Server struct {
 	// Context window management
 	tokenizer           tokenizer.Tokenizer
 	contextWindowConfig service.ContextWindowConfig
+
+	// User profile configuration
+	maxFactsPerUser int
 }
 
 // NewServer creates a new HTTP handler server.
@@ -59,8 +62,8 @@ func NewServer(
 ) *Server {
 	// Create tokenizer based on configuration
 	tok, err := tokenizer.New(tokenizer.Config{
-		Type:    tokenizer.TokenizerType(tokenizerType),
-		Model:   tokenizerModel,
+		Type:  tokenizer.TokenizerType(tokenizerType),
+		Model: tokenizerModel,
 	})
 	if err != nil {
 		logger.Warn("failed to create tokenizer, using default", "err", err)
@@ -87,14 +90,16 @@ func NewServer(
 		logger:              logger,
 		tokenizer:           tok,
 		contextWindowConfig: contextConfig,
+		maxFactsPerUser:     200, // Default capacity per user
 	}
 }
 
 // resolvedSvc holds the correct service instances for a request.
 // Services are always backed by the tenant's dedicated DB.
 type resolvedSvc struct {
-	memory *service.MemoryService
-	ingest *service.IngestService
+	memory      *service.MemoryService
+	ingest      *service.IngestService
+	userProfile *service.UserProfileService
 }
 
 type tenantSvcKey string
@@ -107,9 +112,11 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 			return cached.(resolvedSvc)
 		}
 		memRepo := tidb.NewMemoryRepo(auth.TenantDB, s.autoModel, s.ftsEnabled)
+		factRepo := tidb.NewUserProfileFactRepo(auth.TenantDB)
 		svc := resolvedSvc{
-			memory: service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
-			ingest: service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
+			memory:      service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
+			ingest:      service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
+			userProfile: service.NewUserProfileService(factRepo, s.maxFactsPerUser),
 		}
 		s.svcCache.Store(key, svc)
 		return svc
@@ -119,12 +126,19 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 		return cached.(resolvedSvc)
 	}
 	memRepo := tidb.NewMemoryRepo(auth.TenantDB, s.autoModel, s.ftsEnabled)
+	factRepo := tidb.NewUserProfileFactRepo(auth.TenantDB)
 	svc := resolvedSvc{
-		memory: service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
-		ingest: service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
+		memory:      service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
+		ingest:      service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
+		userProfile: service.NewUserProfileService(factRepo, s.maxFactsPerUser),
 	}
 	s.svcCache.Store(key, svc)
 	return svc
+}
+
+// resolveUserProfileServices returns the UserProfileService for a request.
+func (s *Server) resolveUserProfileServices(auth *domain.AuthInfo) *service.UserProfileService {
+	return s.resolveServices(auth).userProfile
 }
 
 // Router builds the chi router with all routes and middleware.
@@ -165,6 +179,13 @@ func (s *Server) Router(tenantMW, rateLimitMW func(http.Handler) http.Handler) h
 		r.Post("/imports", s.createTask)
 		r.Get("/imports", s.listTasks)
 		r.Get("/imports/{id}", s.getTask)
+
+		// User Profile Facts (structured long-term facts about users).
+		r.Post("/user-profile/facts", s.createFact)
+		r.Get("/user-profile/facts", s.listFacts)
+		r.Get("/user-profile/facts/{id}", s.getFact)
+		r.Put("/user-profile/facts/{id}", s.updateFact)
+		r.Delete("/user-profile/facts/{id}", s.deleteFact)
 
 	})
 

--- a/server/internal/handler/user_profile.go
+++ b/server/internal/handler/user_profile.go
@@ -1,0 +1,182 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/devioslang/memorix/server/internal/domain"
+	"github.com/devioslang/memorix/server/internal/service"
+	"github.com/go-chi/chi/v5"
+)
+
+// createFactRequest is the request body for creating a new fact.
+type createFactRequest struct {
+	UserID     string  `json:"user_id"`
+	Category   string  `json:"category"`
+	Key        string  `json:"key"`
+	Value      string  `json:"value"`
+	Source     string  `json:"source"`
+	Confidence float64 `json:"confidence"`
+}
+
+// factListResponse is the response for listing facts.
+type factListResponse struct {
+	Facts  []domain.UserProfileFact `json:"facts"`
+	Total  int                      `json:"total"`
+	Limit  int                      `json:"limit"`
+	Offset int                      `json:"offset"`
+}
+
+// createFact handles POST /user-profile/facts
+func (s *Server) createFact(w http.ResponseWriter, r *http.Request) {
+	var req createFactRequest
+	if err := decode(r, &req); err != nil {
+		s.handleError(w, err)
+		return
+	}
+
+	auth := authInfo(r)
+	svc := s.resolveUserProfileServices(auth)
+
+	input := service.CreateFactInput{
+		UserID:     req.UserID,
+		Category:   domain.FactCategory(req.Category),
+		Key:        req.Key,
+		Value:      req.Value,
+		Source:     domain.FactSource(req.Source),
+		Confidence: req.Confidence,
+	}
+
+	// Set default confidence for explicit facts if not provided
+	if input.Source == domain.SourceExplicit && input.Confidence == 0 {
+		input.Confidence = 1.0
+	}
+
+	fact, err := svc.CreateFact(r.Context(), input)
+	if err != nil {
+		s.handleError(w, err)
+		return
+	}
+
+	respond(w, http.StatusCreated, fact)
+}
+
+// listFacts handles GET /user-profile/facts
+func (s *Server) listFacts(w http.ResponseWriter, r *http.Request) {
+	auth := authInfo(r)
+	svc := s.resolveUserProfileServices(auth)
+	q := r.URL.Query()
+
+	limit, _ := strconv.Atoi(q.Get("limit"))
+	offset, _ := strconv.Atoi(q.Get("offset"))
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	filter := domain.UserProfileFactFilter{
+		UserID:   q.Get("user_id"),
+		Category: domain.FactCategory(q.Get("category")),
+		Key:      q.Get("key"),
+		Source:   domain.FactSource(q.Get("source")),
+		Limit:    limit,
+		Offset:   offset,
+	}
+
+	facts, total, err := svc.ListFacts(r.Context(), filter)
+	if err != nil {
+		s.handleError(w, err)
+		return
+	}
+
+	if facts == nil {
+		facts = []domain.UserProfileFact{}
+	}
+
+	respond(w, http.StatusOK, factListResponse{
+		Facts:  facts,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
+}
+
+// getFact handles GET /user-profile/facts/{id}
+func (s *Server) getFact(w http.ResponseWriter, r *http.Request) {
+	auth := authInfo(r)
+	svc := s.resolveUserProfileServices(auth)
+	id := chi.URLParam(r, "id")
+
+	fact, err := svc.GetFact(r.Context(), id)
+	if err != nil {
+		s.handleError(w, err)
+		return
+	}
+
+	respond(w, http.StatusOK, fact)
+}
+
+// updateFactRequest is the request body for updating a fact.
+type updateFactRequest struct {
+	Category   *string  `json:"category,omitempty"`
+	Key        *string  `json:"key,omitempty"`
+	Value      *string  `json:"value,omitempty"`
+	Source     *string  `json:"source,omitempty"`
+	Confidence *float64 `json:"confidence,omitempty"`
+}
+
+// updateFact handles PUT /user-profile/facts/{id}
+func (s *Server) updateFact(w http.ResponseWriter, r *http.Request) {
+	var req updateFactRequest
+	if err := decode(r, &req); err != nil {
+		s.handleError(w, err)
+		return
+	}
+
+	auth := authInfo(r)
+	svc := s.resolveUserProfileServices(auth)
+	id := chi.URLParam(r, "id")
+
+	input := service.UpdateFactInput{}
+	if req.Category != nil {
+		cat := domain.FactCategory(*req.Category)
+		input.Category = &cat
+	}
+	if req.Key != nil {
+		input.Key = req.Key
+	}
+	if req.Value != nil {
+		input.Value = req.Value
+	}
+	if req.Source != nil {
+		src := domain.FactSource(*req.Source)
+		input.Source = &src
+	}
+	if req.Confidence != nil {
+		input.Confidence = req.Confidence
+	}
+
+	fact, err := svc.UpdateFact(r.Context(), id, input)
+	if err != nil {
+		s.handleError(w, err)
+		return
+	}
+
+	respond(w, http.StatusOK, fact)
+}
+
+// deleteFact handles DELETE /user-profile/facts/{id}
+func (s *Server) deleteFact(w http.ResponseWriter, r *http.Request) {
+	auth := authInfo(r)
+	svc := s.resolveUserProfileServices(auth)
+	id := chi.URLParam(r, "id")
+
+	if err := svc.DeleteFact(r.Context(), id); err != nil {
+		s.handleError(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -65,3 +65,26 @@ type UploadTaskRepo interface {
 	FetchPending(ctx context.Context, limit int) ([]domain.UploadTask, error)
 	ResetProcessing(ctx context.Context, staleTimeout time.Duration) (int64, error)
 }
+
+// UserProfileFactRepo manages user profile facts (structured long-term facts about users).
+// This implements the "third layer" of ChatGPT's memory system - structured user profile storage.
+type UserProfileFactRepo interface {
+	Create(ctx context.Context, fact *domain.UserProfileFact) error
+	GetByID(ctx context.Context, factID string) (*domain.UserProfileFact, error)
+	GetByUserID(ctx context.Context, userID string) ([]domain.UserProfileFact, error)
+	GetByUserIDAndCategory(ctx context.Context, userID string, category domain.FactCategory) ([]domain.UserProfileFact, error)
+	List(ctx context.Context, f domain.UserProfileFactFilter) (facts []domain.UserProfileFact, total int, err error)
+	Update(ctx context.Context, fact *domain.UserProfileFact) error
+	Delete(ctx context.Context, factID string) error
+	DeleteByUserID(ctx context.Context, userID string) error
+
+	// CountByUserID returns the total number of facts for a user.
+	CountByUserID(ctx context.Context, userID string) (int, error)
+
+	// DeleteOldestLowConfidence deletes facts that are oldest and have lowest confidence.
+	// Used when user exceeds capacity limit. Returns number of facts deleted.
+	DeleteOldestLowConfidence(ctx context.Context, userID string, count int) (int64, error)
+
+	// TouchLastAccessed updates the last_accessed_at timestamp for a fact.
+	TouchLastAccessed(ctx context.Context, factID string) error
+}

--- a/server/internal/repository/tidb/user_profile.go
+++ b/server/internal/repository/tidb/user_profile.go
@@ -1,0 +1,313 @@
+package tidb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/devioslang/memorix/server/internal/domain"
+)
+
+// UserProfileFactRepo implements repository.UserProfileFactRepo using TiDB.
+type UserProfileFactRepo struct {
+	db *sql.DB
+}
+
+// NewUserProfileFactRepo creates a new UserProfileFactRepo.
+func NewUserProfileFactRepo(db *sql.DB) *UserProfileFactRepo {
+	return &UserProfileFactRepo{db: db}
+}
+
+const factAllColumns = `fact_id, user_id, category, key, value, source, confidence, created_at, updated_at, last_accessed_at`
+
+// Create inserts a new user profile fact.
+func (r *UserProfileFactRepo) Create(ctx context.Context, fact *domain.UserProfileFact) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO user_profile_facts (fact_id, user_id, category, key, value, source, confidence, created_at, updated_at, last_accessed_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), NOW(), NOW())`,
+		fact.FactID, fact.UserID, string(fact.Category), fact.Key, fact.Value, string(fact.Source), fact.Confidence,
+	)
+	if err != nil {
+		return fmt.Errorf("create user profile fact: %w", err)
+	}
+	return nil
+}
+
+// GetByID retrieves a fact by its ID.
+func (r *UserProfileFactRepo) GetByID(ctx context.Context, factID string) (*domain.UserProfileFact, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT `+factAllColumns+` FROM user_profile_facts WHERE fact_id = ?`, factID,
+	)
+	return scanUserProfileFact(row)
+}
+
+// GetByUserID retrieves all facts for a user.
+func (r *UserProfileFactRepo) GetByUserID(ctx context.Context, userID string) ([]domain.UserProfileFact, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT `+factAllColumns+` FROM user_profile_facts WHERE user_id = ? ORDER BY updated_at DESC`,
+		userID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get user facts: %w", err)
+	}
+	defer rows.Close()
+
+	return scanUserProfileFacts(rows)
+}
+
+// GetByUserIDAndCategory retrieves facts for a user filtered by category.
+func (r *UserProfileFactRepo) GetByUserIDAndCategory(ctx context.Context, userID string, category domain.FactCategory) ([]domain.UserProfileFact, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT `+factAllColumns+` FROM user_profile_facts WHERE user_id = ? AND category = ? ORDER BY updated_at DESC`,
+		userID, string(category),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get user facts by category: %w", err)
+	}
+	defer rows.Close()
+
+	return scanUserProfileFacts(rows)
+}
+
+// List retrieves facts with filtering and pagination.
+func (r *UserProfileFactRepo) List(ctx context.Context, f domain.UserProfileFactFilter) ([]domain.UserProfileFact, int, error) {
+	conds, args := r.buildFilterConds(f)
+	where := "1=1"
+	if len(conds) > 0 {
+		where = ""
+		for i, cond := range conds {
+			if i > 0 {
+				where += " AND "
+			}
+			where += cond
+		}
+	}
+
+	// Count total matches.
+	var total int
+	countQuery := "SELECT COUNT(*) FROM user_profile_facts WHERE " + where
+	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count facts: %w", err)
+	}
+
+	// Fetch page.
+	limit := f.Limit
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	offset := f.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	dataQuery := "SELECT " + factAllColumns + " FROM user_profile_facts WHERE " +
+		where + " ORDER BY updated_at DESC LIMIT ? OFFSET ?"
+	dataArgs := make([]any, len(args), len(args)+2)
+	copy(dataArgs, args)
+	dataArgs = append(dataArgs, limit, offset)
+
+	rows, err := r.db.QueryContext(ctx, dataQuery, dataArgs...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list facts: %w", err)
+	}
+	defer rows.Close()
+
+	facts, err := scanUserProfileFacts(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+	return facts, total, nil
+}
+
+// Update updates an existing fact.
+func (r *UserProfileFactRepo) Update(ctx context.Context, fact *domain.UserProfileFact) error {
+	result, err := r.db.ExecContext(ctx,
+		`UPDATE user_profile_facts SET category = ?, key = ?, value = ?, source = ?, confidence = ?, updated_at = NOW()
+		 WHERE fact_id = ?`,
+		string(fact.Category), fact.Key, fact.Value, string(fact.Source), fact.Confidence, fact.FactID,
+	)
+	if err != nil {
+		return fmt.Errorf("update user profile fact: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
+// Delete removes a fact by ID.
+func (r *UserProfileFactRepo) Delete(ctx context.Context, factID string) error {
+	result, err := r.db.ExecContext(ctx,
+		`DELETE FROM user_profile_facts WHERE fact_id = ?`,
+		factID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete user profile fact: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
+// DeleteByUserID removes all facts for a user.
+func (r *UserProfileFactRepo) DeleteByUserID(ctx context.Context, userID string) error {
+	_, err := r.db.ExecContext(ctx,
+		`DELETE FROM user_profile_facts WHERE user_id = ?`,
+		userID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete user facts: %w", err)
+	}
+	return nil
+}
+
+// CountByUserID returns the total number of facts for a user.
+func (r *UserProfileFactRepo) CountByUserID(ctx context.Context, userID string) (int, error) {
+	var count int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM user_profile_facts WHERE user_id = ?`,
+		userID,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count user facts: %w", err)
+	}
+	return count, nil
+}
+
+// DeleteOldestLowConfidence deletes facts that are oldest and have lowest confidence.
+// It prioritizes: oldest last_accessed_at, then lowest confidence.
+// Returns number of facts deleted.
+func (r *UserProfileFactRepo) DeleteOldestLowConfidence(ctx context.Context, userID string, count int) (int64, error) {
+	// Find the IDs of facts to delete (oldest accessed + lowest confidence)
+	query := `
+		SELECT fact_id FROM user_profile_facts
+		WHERE user_id = ?
+		ORDER BY last_accessed_at ASC, confidence ASC
+		LIMIT ?
+	`
+	rows, err := r.db.QueryContext(ctx, query, userID, count)
+	if err != nil {
+		return 0, fmt.Errorf("find oldest low confidence facts: %w", err)
+	}
+	defer rows.Close()
+
+	var factIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return 0, fmt.Errorf("scan fact id: %w", err)
+		}
+		factIDs = append(factIDs, id)
+	}
+
+	if len(factIDs) == 0 {
+		return 0, nil
+	}
+
+	// Delete by IDs
+	result, err := r.db.ExecContext(ctx,
+		`DELETE FROM user_profile_facts WHERE fact_id IN (`+placeholders(len(factIDs))+`)`,
+		stringsToArgs(factIDs)...,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("delete oldest low confidence facts: %w", err)
+	}
+	return result.RowsAffected()
+}
+
+// TouchLastAccessed updates the last_accessed_at timestamp for a fact.
+func (r *UserProfileFactRepo) TouchLastAccessed(ctx context.Context, factID string) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE user_profile_facts SET last_accessed_at = NOW() WHERE fact_id = ?`,
+		factID,
+	)
+	if err != nil {
+		return fmt.Errorf("touch last accessed: %w", err)
+	}
+	return nil
+}
+
+func (r *UserProfileFactRepo) buildFilterConds(f domain.UserProfileFactFilter) ([]string, []any) {
+	conds := []string{}
+	args := []any{}
+
+	if f.UserID != "" {
+		conds = append(conds, "user_id = ?")
+		args = append(args, f.UserID)
+	}
+	if f.Category != "" {
+		conds = append(conds, "category = ?")
+		args = append(args, string(f.Category))
+	}
+	if f.Key != "" {
+		conds = append(conds, "`key` = ?")
+		args = append(args, f.Key)
+	}
+	if f.Source != "" {
+		conds = append(conds, "source = ?")
+		args = append(args, string(f.Source))
+	}
+
+	return conds, args
+}
+
+func scanUserProfileFact(row *sql.Row) (*domain.UserProfileFact, error) {
+	var f domain.UserProfileFact
+	var category, source sql.NullString
+
+	err := row.Scan(&f.FactID, &f.UserID, &category, &f.Key, &f.Value, &source, &f.Confidence,
+		&f.CreatedAt, &f.UpdatedAt, &f.LastAccessedAt)
+	if err == sql.ErrNoRows {
+		return nil, domain.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan user profile fact: %w", err)
+	}
+
+	f.Category = domain.FactCategory(category.String)
+	f.Source = domain.FactSource(source.String)
+	return &f, nil
+}
+
+func scanUserProfileFacts(rows *sql.Rows) ([]domain.UserProfileFact, error) {
+	var facts []domain.UserProfileFact
+	for rows.Next() {
+		var f domain.UserProfileFact
+		var category, source sql.NullString
+
+		err := rows.Scan(&f.FactID, &f.UserID, &category, &f.Key, &f.Value, &source, &f.Confidence,
+			&f.CreatedAt, &f.UpdatedAt, &f.LastAccessedAt)
+		if err != nil {
+			return nil, fmt.Errorf("scan user profile fact row: %w", err)
+		}
+
+		f.Category = domain.FactCategory(category.String)
+		f.Source = domain.FactSource(source.String)
+		facts = append(facts, f)
+	}
+	return facts, rows.Err()
+}
+
+// placeholders generates n SQL placeholders separated by commas.
+func placeholders(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	result := "?"
+	for i := 1; i < n; i++ {
+		result += ",?"
+	}
+	return result
+}
+
+// stringsToArgs converts a string slice to []any for use in SQL queries.
+func stringsToArgs(s []string) []any {
+	args := make([]any, len(s))
+	for i, v := range s {
+		args[i] = v
+	}
+	return args
+}

--- a/server/internal/service/tenant.go
+++ b/server/internal/service/tenant.go
@@ -7,10 +7,10 @@ import (
 	"log/slog"
 	"strconv"
 
-	"github.com/go-sql-driver/mysql"
 	"github.com/devioslang/memorix/server/internal/domain"
 	"github.com/devioslang/memorix/server/internal/repository"
 	"github.com/devioslang/memorix/server/internal/tenant"
+	"github.com/go-sql-driver/mysql"
 )
 
 const tenantMemorySchemaBase = `CREATE TABLE IF NOT EXISTS memories (
@@ -35,6 +35,23 @@ const tenantMemorySchemaBase = `CREATE TABLE IF NOT EXISTS memories (
 	    INDEX idx_agent               (agent_id),
 	    INDEX idx_session             (session_id),
 	    INDEX idx_updated             (updated_at)
+	)`
+
+const tenantUserProfileFactsSchema = `CREATE TABLE IF NOT EXISTS user_profile_facts (
+	    fact_id           VARCHAR(36)     PRIMARY KEY,
+	    user_id           VARCHAR(100)    NOT NULL,
+	    category          VARCHAR(20)     NOT NULL COMMENT 'personal|preference|goal|skill',
+	    ` + "`key`" + `             VARCHAR(100)    NOT NULL,
+	    value             TEXT            NOT NULL,
+	    source            VARCHAR(20)     NOT NULL COMMENT 'explicit|inferred',
+	    confidence        DECIMAL(3,2)    NOT NULL DEFAULT 1.0 COMMENT '0.00-1.00, confidence for inferred facts',
+	    created_at        TIMESTAMP       DEFAULT CURRENT_TIMESTAMP,
+	    updated_at        TIMESTAMP       DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	    last_accessed_at  TIMESTAMP       DEFAULT CURRENT_TIMESTAMP COMMENT 'Used for capacity-based cleanup',
+	    INDEX idx_user_facts (user_id),
+	    INDEX idx_user_category (user_id, category),
+	    INDEX idx_user_key (user_id, ` + "`key`" + `),
+	    INDEX idx_accessed_confidence (user_id, last_accessed_at, confidence)
 	)`
 
 func buildMemorySchema(autoModel string, autoDims int) string {
@@ -191,6 +208,10 @@ func (s *TenantService) initSchema(ctx context.Context, t *domain.Tenant) error 
 		if err != nil && !isIndexExistsError(err) {
 			return fmt.Errorf("init tenant schema: fulltext index: %w", err)
 		}
+	}
+	// Create user_profile_facts table for structured user profile storage.
+	if _, err := db.ExecContext(ctx, tenantUserProfileFactsSchema); err != nil {
+		return fmt.Errorf("init tenant schema: user_profile_facts: %w", err)
 	}
 	return nil
 }

--- a/server/internal/service/user_profile.go
+++ b/server/internal/service/user_profile.go
@@ -1,0 +1,231 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/devioslang/memorix/server/internal/domain"
+	"github.com/devioslang/memorix/server/internal/repository"
+	"github.com/google/uuid"
+)
+
+// UserProfileService manages user profile facts.
+type UserProfileService struct {
+	facts           repository.UserProfileFactRepo
+	maxFactsPerUser int
+}
+
+// NewUserProfileService creates a new UserProfileService.
+func NewUserProfileService(facts repository.UserProfileFactRepo, maxFactsPerUser int) *UserProfileService {
+	if maxFactsPerUser <= 0 {
+		maxFactsPerUser = domain.DefaultMaxFactsPerUser
+	}
+	return &UserProfileService{
+		facts:           facts,
+		maxFactsPerUser: maxFactsPerUser,
+	}
+}
+
+// CreateFactInput contains the input for creating a new fact.
+type CreateFactInput struct {
+	UserID     string              `json:"user_id"`
+	Category   domain.FactCategory `json:"category"`
+	Key        string              `json:"key"`
+	Value      string              `json:"value"`
+	Source     domain.FactSource   `json:"source"`
+	Confidence float64             `json:"confidence"`
+}
+
+// UpdateFactInput contains the input for updating a fact.
+type UpdateFactInput struct {
+	Category   *domain.FactCategory `json:"category,omitempty"`
+	Key        *string              `json:"key,omitempty"`
+	Value      *string              `json:"value,omitempty"`
+	Source     *domain.FactSource   `json:"source,omitempty"`
+	Confidence *float64             `json:"confidence,omitempty"`
+}
+
+// CreateFact creates a new user profile fact.
+// It enforces the capacity limit by cleaning up old low-confidence facts if needed.
+func (s *UserProfileService) CreateFact(ctx context.Context, input CreateFactInput) (*domain.UserProfileFact, error) {
+	if err := validateCreateFactInput(input); err != nil {
+		return nil, err
+	}
+
+	// Check capacity and cleanup if needed
+	count, err := s.facts.CountByUserID(ctx, input.UserID)
+	if err != nil {
+		return nil, err
+	}
+
+	if count >= s.maxFactsPerUser {
+		// Need to make room - delete oldest low-confidence facts
+		// Delete one fact to make room for the new one
+		deleted, err := s.facts.DeleteOldestLowConfidence(ctx, input.UserID, 1)
+		if err != nil {
+			return nil, err
+		}
+		if deleted == 0 {
+			// No facts were deleted - this shouldn't happen, but handle gracefully
+			// by allowing the insert anyway (will exceed limit slightly)
+		}
+	}
+
+	now := time.Now()
+	fact := &domain.UserProfileFact{
+		FactID:         uuid.New().String(),
+		UserID:         input.UserID,
+		Category:       input.Category,
+		Key:            input.Key,
+		Value:          input.Value,
+		Source:         input.Source,
+		Confidence:     input.Confidence,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastAccessedAt: now,
+	}
+
+	if err := s.facts.Create(ctx, fact); err != nil {
+		return nil, err
+	}
+
+	return fact, nil
+}
+
+// GetFact retrieves a single fact by ID.
+func (s *UserProfileService) GetFact(ctx context.Context, factID string) (*domain.UserProfileFact, error) {
+	fact, err := s.facts.GetByID(ctx, factID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update last accessed timestamp
+	_ = s.facts.TouchLastAccessed(ctx, factID)
+
+	return fact, nil
+}
+
+// GetFactsByUser retrieves all facts for a user.
+func (s *UserProfileService) GetFactsByUser(ctx context.Context, userID string) ([]domain.UserProfileFact, error) {
+	return s.facts.GetByUserID(ctx, userID)
+}
+
+// GetFactsByCategory retrieves facts for a user filtered by category.
+func (s *UserProfileService) GetFactsByCategory(ctx context.Context, userID string, category domain.FactCategory) ([]domain.UserProfileFact, error) {
+	if !domain.IsValidCategory(category) {
+		return nil, &domain.ValidationError{Field: "category", Message: "invalid category"}
+	}
+	return s.facts.GetByUserIDAndCategory(ctx, userID, category)
+}
+
+// ListFacts retrieves facts with filtering and pagination.
+func (s *UserProfileService) ListFacts(ctx context.Context, filter domain.UserProfileFactFilter) ([]domain.UserProfileFact, int, error) {
+	if filter.UserID == "" {
+		return nil, 0, &domain.ValidationError{Field: "user_id", Message: "required"}
+	}
+	if filter.Category != "" && !domain.IsValidCategory(filter.Category) {
+		return nil, 0, &domain.ValidationError{Field: "category", Message: "invalid category"}
+	}
+	if filter.Source != "" && !domain.IsValidSource(filter.Source) {
+		return nil, 0, &domain.ValidationError{Field: "source", Message: "invalid source"}
+	}
+	return s.facts.List(ctx, filter)
+}
+
+// UpdateFact updates an existing fact.
+func (s *UserProfileService) UpdateFact(ctx context.Context, factID string, input UpdateFactInput) (*domain.UserProfileFact, error) {
+	// Get existing fact
+	fact, err := s.facts.GetByID(ctx, factID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply updates
+	if input.Category != nil {
+		if !domain.IsValidCategory(*input.Category) {
+			return nil, &domain.ValidationError{Field: "category", Message: "invalid category"}
+		}
+		fact.Category = *input.Category
+	}
+	if input.Key != nil {
+		if *input.Key == "" {
+			return nil, &domain.ValidationError{Field: "key", Message: "required"}
+		}
+		if len(*input.Key) > 100 {
+			return nil, &domain.ValidationError{Field: "key", Message: "too long (max 100)"}
+		}
+		fact.Key = *input.Key
+	}
+	if input.Value != nil {
+		if *input.Value == "" {
+			return nil, &domain.ValidationError{Field: "value", Message: "required"}
+		}
+		if len(*input.Value) > 10000 {
+			return nil, &domain.ValidationError{Field: "value", Message: "too long (max 10000)"}
+		}
+		fact.Value = *input.Value
+	}
+	if input.Source != nil {
+		if !domain.IsValidSource(*input.Source) {
+			return nil, &domain.ValidationError{Field: "source", Message: "invalid source"}
+		}
+		fact.Source = *input.Source
+	}
+	if input.Confidence != nil {
+		if *input.Confidence < domain.MinConfidence || *input.Confidence > domain.MaxConfidence {
+			return nil, &domain.ValidationError{Field: "confidence", Message: "must be between 0 and 1"}
+		}
+		fact.Confidence = *input.Confidence
+	}
+
+	fact.UpdatedAt = time.Now()
+
+	if err := s.facts.Update(ctx, fact); err != nil {
+		return nil, err
+	}
+
+	return fact, nil
+}
+
+// DeleteFact deletes a fact by ID.
+func (s *UserProfileService) DeleteFact(ctx context.Context, factID string) error {
+	return s.facts.Delete(ctx, factID)
+}
+
+// DeleteFactsByUser deletes all facts for a user.
+func (s *UserProfileService) DeleteFactsByUser(ctx context.Context, userID string) error {
+	return s.facts.DeleteByUserID(ctx, userID)
+}
+
+// CountFactsByUser returns the number of facts for a user.
+func (s *UserProfileService) CountFactsByUser(ctx context.Context, userID string) (int, error) {
+	return s.facts.CountByUserID(ctx, userID)
+}
+
+func validateCreateFactInput(input CreateFactInput) error {
+	if input.UserID == "" {
+		return &domain.ValidationError{Field: "user_id", Message: "required"}
+	}
+	if !domain.IsValidCategory(input.Category) {
+		return &domain.ValidationError{Field: "category", Message: "invalid category"}
+	}
+	if input.Key == "" {
+		return &domain.ValidationError{Field: "key", Message: "required"}
+	}
+	if len(input.Key) > 100 {
+		return &domain.ValidationError{Field: "key", Message: "too long (max 100)"}
+	}
+	if input.Value == "" {
+		return &domain.ValidationError{Field: "value", Message: "required"}
+	}
+	if len(input.Value) > 10000 {
+		return &domain.ValidationError{Field: "value", Message: "too long (max 10000)"}
+	}
+	if !domain.IsValidSource(input.Source) {
+		return &domain.ValidationError{Field: "source", Message: "invalid source"}
+	}
+	if input.Confidence < domain.MinConfidence || input.Confidence > domain.MaxConfidence {
+		return &domain.ValidationError{Field: "confidence", Message: "must be between 0 and 1"}
+	}
+	return nil
+}

--- a/server/internal/service/user_profile_test.go
+++ b/server/internal/service/user_profile_test.go
@@ -1,0 +1,595 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/devioslang/memorix/server/internal/domain"
+)
+
+// mockUserProfileFactRepo is a mock implementation of repository.UserProfileFactRepo
+type mockUserProfileFactRepo struct {
+	facts       map[string]*domain.UserProfileFact
+	countResult int
+	countErr    error
+}
+
+func newMockUserProfileFactRepo() *mockUserProfileFactRepo {
+	return &mockUserProfileFactRepo{
+		facts: make(map[string]*domain.UserProfileFact),
+	}
+}
+
+func (m *mockUserProfileFactRepo) Create(ctx context.Context, fact *domain.UserProfileFact) error {
+	m.facts[fact.FactID] = fact
+	return nil
+}
+
+func (m *mockUserProfileFactRepo) GetByID(ctx context.Context, factID string) (*domain.UserProfileFact, error) {
+	fact, ok := m.facts[factID]
+	if !ok {
+		return nil, domain.ErrNotFound
+	}
+	return fact, nil
+}
+
+func (m *mockUserProfileFactRepo) GetByUserID(ctx context.Context, userID string) ([]domain.UserProfileFact, error) {
+	var result []domain.UserProfileFact
+	for _, f := range m.facts {
+		if f.UserID == userID {
+			result = append(result, *f)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockUserProfileFactRepo) GetByUserIDAndCategory(ctx context.Context, userID string, category domain.FactCategory) ([]domain.UserProfileFact, error) {
+	var result []domain.UserProfileFact
+	for _, f := range m.facts {
+		if f.UserID == userID && f.Category == category {
+			result = append(result, *f)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockUserProfileFactRepo) List(ctx context.Context, f domain.UserProfileFactFilter) ([]domain.UserProfileFact, int, error) {
+	var result []domain.UserProfileFact
+	for _, fact := range m.facts {
+		if f.UserID != "" && fact.UserID != f.UserID {
+			continue
+		}
+		if f.Category != "" && fact.Category != f.Category {
+			continue
+		}
+		if f.Key != "" && fact.Key != f.Key {
+			continue
+		}
+		if f.Source != "" && fact.Source != f.Source {
+			continue
+		}
+		result = append(result, *fact)
+	}
+	total := len(result)
+	// Simple pagination
+	start := f.Offset
+	if start > total {
+		start = total
+	}
+	end := start + f.Limit
+	if end > total || f.Limit <= 0 {
+		end = total
+	}
+	return result[start:end], total, nil
+}
+
+func (m *mockUserProfileFactRepo) Update(ctx context.Context, fact *domain.UserProfileFact) error {
+	if _, ok := m.facts[fact.FactID]; !ok {
+		return domain.ErrNotFound
+	}
+	m.facts[fact.FactID] = fact
+	return nil
+}
+
+func (m *mockUserProfileFactRepo) Delete(ctx context.Context, factID string) error {
+	if _, ok := m.facts[factID]; !ok {
+		return domain.ErrNotFound
+	}
+	delete(m.facts, factID)
+	return nil
+}
+
+func (m *mockUserProfileFactRepo) DeleteByUserID(ctx context.Context, userID string) error {
+	for id, f := range m.facts {
+		if f.UserID == userID {
+			delete(m.facts, id)
+		}
+	}
+	return nil
+}
+
+func (m *mockUserProfileFactRepo) CountByUserID(ctx context.Context, userID string) (int, error) {
+	if m.countErr != nil {
+		return 0, m.countErr
+	}
+	if m.countResult > 0 {
+		return m.countResult, nil
+	}
+	count := 0
+	for _, f := range m.facts {
+		if f.UserID == userID {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (m *mockUserProfileFactRepo) DeleteOldestLowConfidence(ctx context.Context, userID string, count int) (int64, error) {
+	deleted := int64(0)
+	// Simple implementation: just delete the first 'count' facts for this user
+	for id, f := range m.facts {
+		if f.UserID == userID && deleted < int64(count) {
+			delete(m.facts, id)
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+func (m *mockUserProfileFactRepo) TouchLastAccessed(ctx context.Context, factID string) error {
+	return nil
+}
+
+func TestValidateCreateFactInput(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       CreateFactInput
+		wantErr     bool
+		wantField   string
+		wantMessage string
+	}{
+		{
+			name: "valid input with explicit source",
+			input: CreateFactInput{
+				UserID:     "user-123",
+				Category:   domain.CategoryPersonal,
+				Key:        "name",
+				Value:      "John Doe",
+				Source:     domain.SourceExplicit,
+				Confidence: 1.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid input with inferred source",
+			input: CreateFactInput{
+				UserID:     "user-123",
+				Category:   domain.CategoryPreference,
+				Key:        "language",
+				Value:      "Python",
+				Source:     domain.SourceInferred,
+				Confidence: 0.85,
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing user_id",
+			input: CreateFactInput{
+				Category:   domain.CategoryPersonal,
+				Key:        "name",
+				Value:      "John Doe",
+				Source:     domain.SourceExplicit,
+				Confidence: 1.0,
+			},
+			wantErr:     true,
+			wantField:   "user_id",
+			wantMessage: "required",
+		},
+		{
+			name: "invalid category",
+			input: CreateFactInput{
+				UserID:     "user-123",
+				Category:   "invalid",
+				Key:        "name",
+				Value:      "John Doe",
+				Source:     domain.SourceExplicit,
+				Confidence: 1.0,
+			},
+			wantErr:     true,
+			wantField:   "category",
+			wantMessage: "invalid category",
+		},
+		{
+			name: "missing key",
+			input: CreateFactInput{
+				UserID:     "user-123",
+				Category:   domain.CategoryPersonal,
+				Value:      "John Doe",
+				Source:     domain.SourceExplicit,
+				Confidence: 1.0,
+			},
+			wantErr:     true,
+			wantField:   "key",
+			wantMessage: "required",
+		},
+		{
+			name: "missing value",
+			input: CreateFactInput{
+				UserID:     "user-123",
+				Category:   domain.CategoryPersonal,
+				Key:        "name",
+				Source:     domain.SourceExplicit,
+				Confidence: 1.0,
+			},
+			wantErr:     true,
+			wantField:   "value",
+			wantMessage: "required",
+		},
+		{
+			name: "invalid source",
+			input: CreateFactInput{
+				UserID:     "user-123",
+				Category:   domain.CategoryPersonal,
+				Key:        "name",
+				Value:      "John Doe",
+				Source:     "invalid",
+				Confidence: 1.0,
+			},
+			wantErr:     true,
+			wantField:   "source",
+			wantMessage: "invalid source",
+		},
+		{
+			name: "confidence below 0",
+			input: CreateFactInput{
+				UserID:     "user-123",
+				Category:   domain.CategoryPersonal,
+				Key:        "name",
+				Value:      "John Doe",
+				Source:     domain.SourceExplicit,
+				Confidence: -0.1,
+			},
+			wantErr:     true,
+			wantField:   "confidence",
+			wantMessage: "must be between 0 and 1",
+		},
+		{
+			name: "confidence above 1",
+			input: CreateFactInput{
+				UserID:     "user-123",
+				Category:   domain.CategoryPersonal,
+				Key:        "name",
+				Value:      "John Doe",
+				Source:     domain.SourceExplicit,
+				Confidence: 1.5,
+			},
+			wantErr:     true,
+			wantField:   "confidence",
+			wantMessage: "must be between 0 and 1",
+		},
+		{
+			name: "key too long",
+			input: CreateFactInput{
+				UserID:     "user-123",
+				Category:   domain.CategoryPersonal,
+				Key:        string(make([]byte, 101)),
+				Value:      "John Doe",
+				Source:     domain.SourceExplicit,
+				Confidence: 1.0,
+			},
+			wantErr:     true,
+			wantField:   "key",
+			wantMessage: "too long (max 100)",
+		},
+		{
+			name: "value too long",
+			input: CreateFactInput{
+				UserID:     "user-123",
+				Category:   domain.CategoryPersonal,
+				Key:        "name",
+				Value:      string(make([]byte, 10001)),
+				Source:     domain.SourceExplicit,
+				Confidence: 1.0,
+			},
+			wantErr:     true,
+			wantField:   "value",
+			wantMessage: "too long (max 10000)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCreateFactInput(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("validateCreateFactInput() expected error, got nil")
+					return
+				}
+				var ve *domain.ValidationError
+				if !errors.As(err, &ve) {
+					t.Errorf("validateCreateFactInput() expected ValidationError, got %T", err)
+					return
+				}
+				if ve.Field != tt.wantField {
+					t.Errorf("validateCreateFactInput() field = %q, want %q", ve.Field, tt.wantField)
+				}
+				if ve.Message != tt.wantMessage {
+					t.Errorf("validateCreateFactInput() message = %q, want %q", ve.Message, tt.wantMessage)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("validateCreateFactInput() unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestUserProfileService_CreateFact(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         CreateFactInput
+		existingCount int
+		wantErr       bool
+	}{
+		{
+			name: "create fact successfully",
+			input: CreateFactInput{
+				UserID:     "user-123",
+				Category:   domain.CategoryPersonal,
+				Key:        "name",
+				Value:      "John Doe",
+				Source:     domain.SourceExplicit,
+				Confidence: 1.0,
+			},
+			existingCount: 0,
+			wantErr:       false,
+		},
+		{
+			name: "create fact when at capacity triggers cleanup",
+			input: CreateFactInput{
+				UserID:     "user-123",
+				Category:   domain.CategoryPersonal,
+				Key:        "new_fact",
+				Value:      "New Value",
+				Source:     domain.SourceExplicit,
+				Confidence: 1.0,
+			},
+			existingCount: 200,
+			wantErr:       false,
+		},
+		{
+			name: "invalid input returns error",
+			input: CreateFactInput{
+				UserID: "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := newMockUserProfileFactRepo()
+			mockRepo.countResult = tt.existingCount
+			svc := NewUserProfileService(mockRepo, 200)
+
+			fact, err := svc.CreateFact(context.Background(), tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("CreateFact() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("CreateFact() unexpected error: %v", err)
+				return
+			}
+			if fact == nil {
+				t.Errorf("CreateFact() returned nil fact")
+				return
+			}
+			if fact.FactID == "" {
+				t.Errorf("CreateFact() returned fact with empty ID")
+			}
+			if fact.UserID != tt.input.UserID {
+				t.Errorf("CreateFact() UserID = %q, want %q", fact.UserID, tt.input.UserID)
+			}
+			if fact.Category != tt.input.Category {
+				t.Errorf("CreateFact() Category = %q, want %q", fact.Category, tt.input.Category)
+			}
+		})
+	}
+}
+
+func TestUserProfileService_GetFact(t *testing.T) {
+	mockRepo := newMockUserProfileFactRepo()
+	svc := NewUserProfileService(mockRepo, 200)
+
+	// Create a fact first
+	created, _ := svc.CreateFact(context.Background(), CreateFactInput{
+		UserID:     "user-123",
+		Category:   domain.CategoryPersonal,
+		Key:        "name",
+		Value:      "John Doe",
+		Source:     domain.SourceExplicit,
+		Confidence: 1.0,
+	})
+
+	// Test retrieval
+	fact, err := svc.GetFact(context.Background(), created.FactID)
+	if err != nil {
+		t.Errorf("GetFact() unexpected error: %v", err)
+		return
+	}
+	if fact.FactID != created.FactID {
+		t.Errorf("GetFact() FactID = %q, want %q", fact.FactID, created.FactID)
+	}
+
+	// Test not found
+	_, err = svc.GetFact(context.Background(), "non-existent")
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("GetFact() expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestUserProfileService_GetFactsByCategory(t *testing.T) {
+	mockRepo := newMockUserProfileFactRepo()
+	svc := NewUserProfileService(mockRepo, 200)
+
+	// Create facts in different categories
+	svc.CreateFact(context.Background(), CreateFactInput{
+		UserID:     "user-123",
+		Category:   domain.CategoryPersonal,
+		Key:        "name",
+		Value:      "John Doe",
+		Source:     domain.SourceExplicit,
+		Confidence: 1.0,
+	})
+	svc.CreateFact(context.Background(), CreateFactInput{
+		UserID:     "user-123",
+		Category:   domain.CategoryPreference,
+		Key:        "language",
+		Value:      "Python",
+		Source:     domain.SourceExplicit,
+		Confidence: 1.0,
+	})
+
+	// Test category filter
+	facts, err := svc.GetFactsByCategory(context.Background(), "user-123", domain.CategoryPersonal)
+	if err != nil {
+		t.Errorf("GetFactsByCategory() unexpected error: %v", err)
+		return
+	}
+	if len(facts) != 1 {
+		t.Errorf("GetFactsByCategory() returned %d facts, want 1", len(facts))
+		return
+	}
+	if facts[0].Category != domain.CategoryPersonal {
+		t.Errorf("GetFactsByCategory() Category = %q, want %q", facts[0].Category, domain.CategoryPersonal)
+	}
+
+	// Test invalid category
+	_, err = svc.GetFactsByCategory(context.Background(), "user-123", "invalid")
+	if err == nil {
+		t.Errorf("GetFactsByCategory() expected error for invalid category")
+	}
+}
+
+func TestUserProfileService_UpdateFact(t *testing.T) {
+	mockRepo := newMockUserProfileFactRepo()
+	svc := NewUserProfileService(mockRepo, 200)
+
+	// Create a fact first
+	created, _ := svc.CreateFact(context.Background(), CreateFactInput{
+		UserID:     "user-123",
+		Category:   domain.CategoryPersonal,
+		Key:        "name",
+		Value:      "John Doe",
+		Source:     domain.SourceExplicit,
+		Confidence: 1.0,
+	})
+
+	// Test update
+	newValue := "Jane Doe"
+	updated, err := svc.UpdateFact(context.Background(), created.FactID, UpdateFactInput{
+		Value: &newValue,
+	})
+	if err != nil {
+		t.Errorf("UpdateFact() unexpected error: %v", err)
+		return
+	}
+	if updated.Value != newValue {
+		t.Errorf("UpdateFact() Value = %q, want %q", updated.Value, newValue)
+	}
+
+	// Test update non-existent fact
+	_, err = svc.UpdateFact(context.Background(), "non-existent", UpdateFactInput{
+		Value: &newValue,
+	})
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("UpdateFact() expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestUserProfileService_DeleteFact(t *testing.T) {
+	mockRepo := newMockUserProfileFactRepo()
+	svc := NewUserProfileService(mockRepo, 200)
+
+	// Create a fact first
+	created, _ := svc.CreateFact(context.Background(), CreateFactInput{
+		UserID:     "user-123",
+		Category:   domain.CategoryPersonal,
+		Key:        "name",
+		Value:      "John Doe",
+		Source:     domain.SourceExplicit,
+		Confidence: 1.0,
+	})
+
+	// Test delete
+	err := svc.DeleteFact(context.Background(), created.FactID)
+	if err != nil {
+		t.Errorf("DeleteFact() unexpected error: %v", err)
+		return
+	}
+
+	// Verify deleted
+	_, err = svc.GetFact(context.Background(), created.FactID)
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("GetFact() expected ErrNotFound after delete, got %v", err)
+	}
+
+	// Test delete non-existent fact
+	err = svc.DeleteFact(context.Background(), "non-existent")
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("DeleteFact() expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestUserProfileService_ListFacts(t *testing.T) {
+	mockRepo := newMockUserProfileFactRepo()
+	svc := NewUserProfileService(mockRepo, 200)
+
+	// Create multiple facts
+	for i := 0; i < 5; i++ {
+		svc.CreateFact(context.Background(), CreateFactInput{
+			UserID:     "user-123",
+			Category:   domain.CategoryPersonal,
+			Key:        "key" + string(rune('a'+i)),
+			Value:      "value",
+			Source:     domain.SourceExplicit,
+			Confidence: 1.0,
+		})
+	}
+
+	// Test list
+	facts, total, err := svc.ListFacts(context.Background(), domain.UserProfileFactFilter{
+		UserID: "user-123",
+		Limit:  10,
+	})
+	if err != nil {
+		t.Errorf("ListFacts() unexpected error: %v", err)
+		return
+	}
+	if total != 5 {
+		t.Errorf("ListFacts() total = %d, want 5", total)
+	}
+	if len(facts) != 5 {
+		t.Errorf("ListFacts() returned %d facts, want 5", len(facts))
+	}
+
+	// Test missing user_id
+	_, _, err = svc.ListFacts(context.Background(), domain.UserProfileFactFilter{})
+	if err == nil {
+		t.Errorf("ListFacts() expected error for missing user_id")
+	}
+}
+
+func TestUserProfileService_DefaultMaxFacts(t *testing.T) {
+	mockRepo := newMockUserProfileFactRepo()
+	// Test with default max facts
+	svc := NewUserProfileService(mockRepo, 0) // 0 should use default
+	if svc.maxFactsPerUser != domain.DefaultMaxFactsPerUser {
+		t.Errorf("NewUserProfileService() maxFactsPerUser = %d, want %d", svc.maxFactsPerUser, domain.DefaultMaxFactsPerUser)
+	}
+}

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -128,3 +128,26 @@ CREATE TABLE IF NOT EXISTS upload_tasks (
   INDEX idx_upload_tenant (tenant_id),
   INDEX idx_upload_poll (status, created_at)
 );
+
+-- User profile facts (structured long-term facts about users).
+-- Based on ChatGPT's "third layer" user memory - structured profile storage.
+CREATE TABLE IF NOT EXISTS user_profile_facts (
+  fact_id           VARCHAR(36)     PRIMARY KEY,
+  user_id           VARCHAR(100)    NOT NULL,
+  category          VARCHAR(20)     NOT NULL
+                      COMMENT 'personal|preference|goal|skill',
+  `key`             VARCHAR(100)    NOT NULL,
+  value             TEXT            NOT NULL,
+  source            VARCHAR(20)     NOT NULL
+                      COMMENT 'explicit|inferred',
+  confidence        DECIMAL(3,2)    NOT NULL DEFAULT 1.0
+                      COMMENT '0.00-1.00, confidence for inferred facts',
+  created_at        TIMESTAMP       DEFAULT CURRENT_TIMESTAMP,
+  updated_at        TIMESTAMP       DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  last_accessed_at  TIMESTAMP       DEFAULT CURRENT_TIMESTAMP
+                      COMMENT 'Used for capacity-based cleanup',
+  INDEX idx_user_facts (user_id),
+  INDEX idx_user_category (user_id, category),
+  INDEX idx_user_key (user_id, `key`),
+  INDEX idx_accessed_confidence (user_id, last_accessed_at, confidence)
+);


### PR DESCRIPTION
## Summary
- Add structured long-term fact storage for users based on ChatGPT's "third layer" user memory design
- Implement UserProfileFact domain model with categories (personal, preference, goal, skill) and sources (explicit, inferred)
- Create full CRUD API for user profile facts with validation and capacity management

## Key Changes
- **Domain Model**: `UserProfileFact` struct with all required fields (fact_id, user_id, category, key, value, source, confidence, timestamps)
- **Repository Layer**: `UserProfileFactRepo` interface and TiDB implementation with CRUD operations
- **Service Layer**: `UserProfileService` with validation, capacity limits (200 facts/user), and automatic cleanup
- **HTTP Handlers**: REST API endpoints at `/v1alpha1/memorix/{tenantID}/user-profile/facts`
- **Database Schema**: `user_profile_facts` table with indexes for efficient querying

## API Endpoints
- `POST /user-profile/facts` - Create a fact
- `GET /user-profile/facts` - List facts (filter by user_id required)
- `GET /user-profile/facts/{id}` - Get single fact
- `PUT /user-profile/facts/{id}` - Update fact
- `DELETE /user-profile/facts/{id}` - Delete fact

## Capacity Management
- 200 facts per user limit
- Automatic cleanup of oldest low-confidence facts when capacity is reached
- Prioritizes keeping high-confidence and recently accessed facts

## Test Plan
- [x] Unit tests pass for UserProfileService
- [x] `make test` passes
- [x] `make vet` passes
- [x] Build succeeds

Closes #2