### PR TITLE
feat: implement session metadata collection and injection

### DIFF
--- a/server/cmd/memorix-server/main.go
+++ b/server/cmd/memorix-server/main.go
@@ -112,6 +112,7 @@ func main() {
 		cfg.TokenizerModel,
 		cfg.SystemPromptReservedTokens,
 		cfg.MemoryReservedTokens,
+		cfg.MetadataReservedTokens,
 	)
 	router := srv.Router(tenantMW, rateMW)
 

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -72,6 +72,10 @@ type Config struct {
 	// MemoryReservedTokens reserves tokens for memory injection area.
 	// Default is 2000 tokens.
 	MemoryReservedTokens int
+
+	// MetadataReservedTokens reserves tokens for session metadata injection.
+	// Default is 200 tokens (per acceptance criteria).
+	MetadataReservedTokens int
 }
 
 func Load() (*Config, error) {
@@ -110,6 +114,7 @@ func Load() (*Config, error) {
 		TokenizerModel:        envOr("MNEMO_TOKENIZER_MODEL", "gpt-4"),
 		SystemPromptReservedTokens:  envInt("MNEMO_SYSTEM_PROMPT_RESERVED_TOKENS", 500),
 		MemoryReservedTokens:  envInt("MNEMO_MEMORY_RESERVED_TOKENS", 2000),
+		MetadataReservedTokens: envInt("MNEMO_METADATA_RESERVED_TOKENS", 200),
 	}
 	// Validate ingest mode.
 	switch cfg.IngestMode {

--- a/server/internal/domain/session_metadata.go
+++ b/server/internal/domain/session_metadata.go
@@ -1,0 +1,103 @@
+package domain
+
+import (
+	"fmt"
+	"time"
+)
+
+// SessionMetadata represents transient metadata that is collected at the start
+// of each session and injected into the system prompt. Unlike memories, this
+// data is not stored long-term and is refreshed on each new session.
+//
+// This is inspired by ChatGPT's "session metadata" layer that provides
+// contextual information to help adjust response style in real-time.
+type SessionMetadata struct {
+	// Basic Information
+
+	// DeviceType indicates the type of device the user is using.
+	// Examples: "desktop", "mobile", "tablet", "cli"
+	DeviceType string `json:"device_type,omitempty"`
+
+	// Timezone is the user's timezone, e.g., "Asia/Shanghai", "America/New_York"
+	Timezone string `json:"timezone,omitempty"`
+
+	// LanguagePreference is the user's preferred language, e.g., "zh-CN", "en-US"
+	LanguagePreference string `json:"language_preference,omitempty"`
+
+	// Session Context
+
+	// CurrentTime is the timestamp when the session started.
+	CurrentTime time.Time `json:"current_time,omitempty"`
+
+	// EntrySource indicates how the user started this session.
+	// Examples: "web", "api", "cli", "plugin", "mobile_app"
+	EntrySource string `json:"entry_source,omitempty"`
+
+	// ClientVersion is the version of the client application.
+	ClientVersion string `json:"client_version,omitempty"`
+
+	// Optional Usage Statistics
+
+	// ActiveDaysLast7 is the number of days the user was active in the last 7 days.
+	ActiveDaysLast7 *int `json:"active_days_last_7,omitempty"`
+
+	// ActiveDaysLast30 is the number of days the user was active in the last 30 days.
+	ActiveDaysLast30 *int `json:"active_days_last_30,omitempty"`
+
+	// AverageMessageLength is the average length of user messages in characters.
+	AverageMessageLength *float64 `json:"average_message_length,omitempty"`
+
+	// TotalSessions is the total number of sessions the user has had.
+	TotalSessions *int `json:"total_sessions,omitempty"`
+}
+
+// Validate checks that the session metadata fields are valid.
+func (m *SessionMetadata) Validate() error {
+	if m.DeviceType != "" {
+		validDevices := []string{"desktop", "mobile", "tablet", "cli", "api", "unknown"}
+		if !contains(validDevices, m.DeviceType) {
+			return &ValidationError{
+				Field:   "device_type",
+				Message: fmt.Sprintf("must be one of: %v", validDevices),
+			}
+		}
+	}
+	return nil
+}
+
+// contains is a helper function to check if a string is in a slice.
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// SessionMetadataFromHeaders extracts session metadata from HTTP headers.
+// This is a convenience function for common header-based metadata extraction.
+func SessionMetadataFromHeaders(headers map[string]string) *SessionMetadata {
+	metadata := &SessionMetadata{}
+
+	if v, ok := headers["X-Device-Type"]; ok {
+		metadata.DeviceType = v
+	}
+	if v, ok := headers["X-Timezone"]; ok {
+		metadata.Timezone = v
+	}
+	if v, ok := headers["X-Language"]; ok {
+		metadata.LanguagePreference = v
+	}
+	if v, ok := headers["X-Entry-Source"]; ok {
+		metadata.EntrySource = v
+	}
+	if v, ok := headers["X-Client-Version"]; ok {
+		metadata.ClientVersion = v
+	}
+
+	// Set current time if not provided
+	metadata.CurrentTime = time.Now()
+
+	return metadata
+}

--- a/server/internal/domain/session_metadata_test.go
+++ b/server/internal/domain/session_metadata_test.go
@@ -1,0 +1,154 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSessionMetadata_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		metadata *SessionMetadata
+		wantErr bool
+	}{
+		{
+			name:    "nil metadata",
+			metadata: nil,
+			wantErr: false,
+		},
+		{
+			name: "valid metadata with all fields",
+			metadata: &SessionMetadata{
+				DeviceType:          "desktop",
+				Timezone:            "Asia/Shanghai",
+				LanguagePreference:  "zh-CN",
+				CurrentTime:         time.Now(),
+				EntrySource:         "web",
+				ClientVersion:       "1.0.0",
+				ActiveDaysLast7:     intPtr(5),
+				ActiveDaysLast30:    intPtr(20),
+				AverageMessageLength: floatPtr(150.0),
+				TotalSessions:       intPtr(100),
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid metadata with minimal fields",
+			metadata: &SessionMetadata{
+				DeviceType:  "mobile",
+				CurrentTime: time.Now(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid device type",
+			metadata: &SessionMetadata{
+				DeviceType: "invalid_device",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid device types",
+			metadata: &SessionMetadata{
+				DeviceType: "cli",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid device type api",
+			metadata: &SessionMetadata{
+				DeviceType: "api",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.metadata == nil {
+				return // nil metadata is valid
+			}
+			err := tt.metadata.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SessionMetadata.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSessionMetadataFromHeaders(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string]string
+		expected *SessionMetadata
+	}{
+		{
+			name:     "empty headers",
+			headers:  map[string]string{},
+			expected: &SessionMetadata{CurrentTime: time.Now()},
+		},
+		{
+			name: "all headers present",
+			headers: map[string]string{
+				"X-Device-Type":    "desktop",
+				"X-Timezone":       "America/New_York",
+				"X-Language":       "en-US",
+				"X-Entry-Source":   "cli",
+				"X-Client-Version": "2.0.0",
+			},
+			expected: &SessionMetadata{
+				DeviceType:         "desktop",
+				Timezone:           "America/New_York",
+				LanguagePreference: "en-US",
+				EntrySource:        "cli",
+				ClientVersion:      "2.0.0",
+				CurrentTime:        time.Now(),
+			},
+		},
+		{
+			name: "partial headers",
+			headers: map[string]string{
+				"X-Device-Type": "mobile",
+				"X-Timezone":    "Europe/London",
+			},
+			expected: &SessionMetadata{
+				DeviceType:  "mobile",
+				Timezone:    "Europe/London",
+				CurrentTime: time.Now(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SessionMetadataFromHeaders(tt.headers)
+			if result.DeviceType != tt.expected.DeviceType {
+				t.Errorf("DeviceType = %v, want %v", result.DeviceType, tt.expected.DeviceType)
+			}
+			if result.Timezone != tt.expected.Timezone {
+				t.Errorf("Timezone = %v, want %v", result.Timezone, tt.expected.Timezone)
+			}
+			if result.LanguagePreference != tt.expected.LanguagePreference {
+				t.Errorf("LanguagePreference = %v, want %v", result.LanguagePreference, tt.expected.LanguagePreference)
+			}
+			if result.EntrySource != tt.expected.EntrySource {
+				t.Errorf("EntrySource = %v, want %v", result.EntrySource, tt.expected.EntrySource)
+			}
+			if result.ClientVersion != tt.expected.ClientVersion {
+				t.Errorf("ClientVersion = %v, want %v", result.ClientVersion, tt.expected.ClientVersion)
+			}
+			if result.CurrentTime.IsZero() {
+				t.Error("CurrentTime should be set")
+			}
+		})
+	}
+}
+
+// Helper functions
+func intPtr(i int) *int {
+	return &i
+}
+
+func floatPtr(f float64) *float64 {
+	return &f
+}

--- a/server/internal/handler/context_window.go
+++ b/server/internal/handler/context_window.go
@@ -18,6 +18,10 @@ type contextWindowRequest struct {
 	// System prompt content (will be injected as a system message).
 	SystemPrompt string `json:"system_prompt,omitempty"`
 
+	// Session metadata for injection (collected at session start, not stored long-term).
+	// This is injected before memory content.
+	SessionMetadata *domain.SessionMetadata `json:"session_metadata,omitempty"`
+
 	// Memory content (will be injected as a memory message).
 	MemoryContent string `json:"memory_content,omitempty"`
 
@@ -45,7 +49,7 @@ type contextWindowResponse struct {
 }
 
 // contextWindow handles POST requests to truncate a message list to fit within token limits.
-// It preserves system prompts and memory injections while dropping oldest user/assistant pairs first.
+// It preserves system prompts, session metadata, and memory injections while dropping oldest user/assistant pairs first.
 func (s *Server) contextWindow(w http.ResponseWriter, r *http.Request) {
 	var req contextWindowRequest
 	if err := decode(r, &req); err != nil {
@@ -59,7 +63,8 @@ func (s *Server) contextWindow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build the full message list with injected content
-	messages := make([]service.ContextMessage, 0, len(req.Messages)+2)
+	// Order: system -> metadata -> memory -> conversation
+	messages := make([]service.ContextMessage, 0, len(req.Messages)+3)
 
 	// Add system prompt if provided
 	if req.SystemPrompt != "" {
@@ -67,6 +72,18 @@ func (s *Server) contextWindow(w http.ResponseWriter, r *http.Request) {
 			Role:    "system",
 			Content: req.SystemPrompt,
 		})
+	}
+
+	// Add session metadata if provided (before memory, after system)
+	if req.SessionMetadata != nil {
+		metadataMsg, err := service.BuildMetadataMessage(req.SessionMetadata, service.NewSessionMetadataFormatter(service.DefaultSessionMetadataConfig()))
+		if err != nil {
+			s.handleError(w, err)
+			return
+		}
+		if metadataMsg.Content != "" {
+			messages = append(messages, metadataMsg)
+		}
 	}
 
 	// Add memory content if provided
@@ -110,10 +127,11 @@ func (s *Server) contextWindow(w http.ResponseWriter, r *http.Request) {
 
 // quickTruncateRequest is for simple truncation without detailed response.
 type quickTruncateRequest struct {
-	Messages      []service.ContextMessage `json:"messages"`
-	MaxTokens     *int                     `json:"max_tokens,omitempty"`
-	SystemPrompt  string                   `json:"system_prompt,omitempty"`
-	MemoryContent string                   `json:"memory_content,omitempty"`
+	Messages        []service.ContextMessage `json:"messages"`
+	MaxTokens       *int                     `json:"max_tokens,omitempty"`
+	SystemPrompt    string                   `json:"system_prompt,omitempty"`
+	SessionMetadata *domain.SessionMetadata  `json:"session_metadata,omitempty"`
+	MemoryContent   string                   `json:"memory_content,omitempty"`
 }
 
 // quickTruncateResponse returns just the truncated messages.
@@ -135,10 +153,20 @@ func (s *Server) quickTruncate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build the full message list
-	messages := make([]service.ContextMessage, 0, len(req.Messages)+2)
+	// Order: system -> metadata -> memory -> conversation
+	messages := make([]service.ContextMessage, 0, len(req.Messages)+3)
 	if req.SystemPrompt != "" {
 		messages = append(messages, service.ContextMessage{Role: "system", Content: req.SystemPrompt})
 	}
+
+	// Add session metadata if provided (before memory, after system)
+	if req.SessionMetadata != nil {
+		metadataMsg, err := service.BuildMetadataMessage(req.SessionMetadata, service.NewSessionMetadataFormatter(service.DefaultSessionMetadataConfig()))
+		if err == nil && metadataMsg.Content != "" {
+			messages = append(messages, metadataMsg)
+		}
+	}
+
 	if req.MemoryContent != "" {
 		messages = append(messages, service.ContextMessage{Role: "memory", Content: req.MemoryContent})
 	}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -59,6 +59,7 @@ func NewServer(
 	tokenizerModel string,
 	systemPromptReservedTokens int,
 	memoryReservedTokens int,
+	metadataReservedTokens int,
 ) *Server {
 	// Create tokenizer based on configuration
 	tok, err := tokenizer.New(tokenizer.Config{
@@ -75,6 +76,7 @@ func NewServer(
 		MaxTokens:                  maxContextTokens,
 		SystemPromptReservedTokens: systemPromptReservedTokens,
 		MemoryReservedTokens:       memoryReservedTokens,
+		MetadataReservedTokens:     metadataReservedTokens,
 		Tokenizer:                  tok,
 	}
 

--- a/server/internal/service/context_window.go
+++ b/server/internal/service/context_window.go
@@ -19,6 +19,10 @@ type ContextWindowConfig struct {
 	// MemoryReservedTokens reserves tokens for memory injection area.
 	MemoryReservedTokens int
 
+	// MetadataReservedTokens reserves tokens for session metadata injection.
+	// Default is 200 tokens (per acceptance criteria).
+	MetadataReservedTokens int
+
 	// Tokenizer is the tokenizer to use for counting tokens.
 	Tokenizer tokenizer.Tokenizer
 }
@@ -29,6 +33,7 @@ func DefaultContextWindowConfig() ContextWindowConfig {
 		MaxTokens:                  8192,
 		SystemPromptReservedTokens: 500,
 		MemoryReservedTokens:       2000,
+		MetadataReservedTokens:     200,
 		Tokenizer:                  tokenizer.NewDefault(),
 	}
 }
@@ -36,9 +41,10 @@ func DefaultContextWindowConfig() ContextWindowConfig {
 // ContextWindow manages token-based sliding window truncation for conversation context.
 // It ensures that:
 // 1. System prompts are always preserved (not truncated)
-// 2. Memory injection areas are always preserved (not truncated)
-// 3. User/assistant message pairs are truncated from the oldest first
-// 4. The total token count stays within the configured limit
+// 2. Session metadata is always preserved (not truncated) - injected once per session
+// 3. Memory injection areas are always preserved (not truncated)
+// 4. User/assistant message pairs are truncated from the oldest first
+// 5. The total token count stays within the configured limit
 type ContextWindow struct {
 	config ContextWindowConfig
 }
@@ -57,12 +63,16 @@ func NewContextWindow(config ContextWindowConfig) *ContextWindow {
 	if config.MemoryReservedTokens <= 0 {
 		config.MemoryReservedTokens = 2000
 	}
+	if config.MetadataReservedTokens <= 0 {
+		config.MetadataReservedTokens = 200
+	}
 	return &ContextWindow{config: config}
 }
 
 // ContextMessage represents a message in the conversation context.
 type ContextMessage struct {
-	// Role is the message role: "system", "user", "assistant", or "memory".
+	// Role is the message role: "system", "user", "assistant", "metadata", or "memory".
+	// "metadata" is a special role for session metadata that is never truncated.
 	// "memory" is a special role for injected memory context that is never truncated.
 	Role string `json:"role"`
 
@@ -95,11 +105,11 @@ type TruncationResult struct {
 }
 
 // Truncate applies the sliding window truncation strategy to the messages.
-// It preserves system messages and memory injections, truncating user/assistant
+// It preserves system messages, metadata, and memory injections, truncating user/assistant
 // pairs from the oldest first to fit within the token limit.
 func (cw *ContextWindow) Truncate(messages []ContextMessage) *TruncationResult {
-	// Calculate available tokens after reserving space for system and memory
-	reservedTokens := cw.config.SystemPromptReservedTokens + cw.config.MemoryReservedTokens
+	// Calculate available tokens after reserving space for system, metadata, and memory
+	reservedTokens := cw.config.SystemPromptReservedTokens + cw.config.MemoryReservedTokens + cw.config.MetadataReservedTokens
 	availableTokens := cw.config.MaxTokens - reservedTokens
 	if availableTokens < 100 {
 		availableTokens = 100 // Minimum usable context
@@ -107,6 +117,7 @@ func (cw *ContextWindow) Truncate(messages []ContextMessage) *TruncationResult {
 
 	// Separate messages into categories
 	var systemMessages []ContextMessage
+	var metadataMessages []ContextMessage
 	var memoryMessages []ContextMessage
 	var conversationMessages []ContextMessage
 
@@ -114,6 +125,8 @@ func (cw *ContextWindow) Truncate(messages []ContextMessage) *TruncationResult {
 		switch msg.Role {
 		case "system":
 			systemMessages = append(systemMessages, msg)
+		case "metadata":
+			metadataMessages = append(metadataMessages, msg)
 		case "memory":
 			memoryMessages = append(memoryMessages, msg)
 		default:
@@ -123,13 +136,14 @@ func (cw *ContextWindow) Truncate(messages []ContextMessage) *TruncationResult {
 
 	// Calculate tokens for preserved messages
 	systemTokens := cw.countTokens(systemMessages)
+	metadataTokens := cw.countTokens(metadataMessages)
 	memoryTokens := cw.countTokens(memoryMessages)
 
-	// Adjust available tokens based on actual system/memory usage
-	availableForConversation := availableTokens - systemTokens - memoryTokens
+	// Adjust available tokens based on actual system/metadata/memory usage
+	availableForConversation := availableTokens - systemTokens - metadataTokens - memoryTokens
 	if availableForConversation < 100 {
 		// If reserved space is already exceeded, try to still fit some conversation
-		availableForConversation = cw.config.MaxTokens/4 - systemTokens - memoryTokens
+		availableForConversation = cw.config.MaxTokens/4 - systemTokens - metadataTokens - memoryTokens
 		if availableForConversation < 50 {
 			availableForConversation = 50
 		}
@@ -142,8 +156,10 @@ func (cw *ContextWindow) Truncate(messages []ContextMessage) *TruncationResult {
 	truncated, dropped := cw.truncateConversation(conversationMessages, availableForConversation)
 
 	// Build final message list
-	result := make([]ContextMessage, 0, len(systemMessages)+len(memoryMessages)+len(truncated))
+	// Order: system -> metadata -> memory -> conversation
+	result := make([]ContextMessage, 0, len(systemMessages)+len(metadataMessages)+len(memoryMessages)+len(truncated))
 	result = append(result, systemMessages...)
+	result = append(result, metadataMessages...)
 	result = append(result, memoryMessages...)
 	result = append(result, truncated...)
 

--- a/server/internal/service/session_metadata.go
+++ b/server/internal/service/session_metadata.go
@@ -1,0 +1,268 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/devioslang/memorix/server/internal/domain"
+	"github.com/devioslang/memorix/server/internal/tokenizer"
+)
+
+// SessionMetadataConfig holds configuration for session metadata handling.
+type SessionMetadataConfig struct {
+	// MaxTokens is the maximum number of tokens allowed for metadata injection.
+	// Default is 200 tokens as per the acceptance criteria.
+	MaxTokens int
+
+	// Tokenizer is used to count tokens in the formatted metadata.
+	Tokenizer tokenizer.Tokenizer
+}
+
+// DefaultSessionMetadataConfig returns sensible defaults.
+func DefaultSessionMetadataConfig() SessionMetadataConfig {
+	return SessionMetadataConfig{
+		MaxTokens: 200,
+		Tokenizer: tokenizer.NewDefault(),
+	}
+}
+
+// SessionMetadataFormatter formats session metadata for injection into system prompts.
+type SessionMetadataFormatter struct {
+	config    SessionMetadataConfig
+	tokenizer tokenizer.Tokenizer
+}
+
+// NewSessionMetadataFormatter creates a new formatter with the given configuration.
+func NewSessionMetadataFormatter(config SessionMetadataConfig) *SessionMetadataFormatter {
+	if config.Tokenizer == nil {
+		config.Tokenizer = tokenizer.NewDefault()
+	}
+	if config.MaxTokens <= 0 {
+		config.MaxTokens = 200
+	}
+	return &SessionMetadataFormatter{
+		config:    config,
+		tokenizer: config.Tokenizer,
+	}
+}
+
+// Format formats the session metadata into a text block suitable for injection
+// into the system prompt. The output is designed to be concise and informative.
+//
+// The format is:
+//
+//	<session-metadata>
+//	Device: desktop
+//	Time: 2024-01-15 14:30 (Asia/Shanghai)
+//	Language: zh-CN
+//	Source: web
+//	</session-metadata>
+func (f *SessionMetadataFormatter) Format(metadata *domain.SessionMetadata) string {
+	if metadata == nil {
+		return ""
+	}
+
+	var lines []string
+	lines = append(lines, "<session-metadata>")
+
+	// Current time with timezone (always included)
+	timeStr := f.formatTime(metadata)
+	if timeStr != "" {
+		lines = append(lines, fmt.Sprintf("Time: %s", timeStr))
+	}
+
+	// Device type
+	if metadata.DeviceType != "" {
+		lines = append(lines, fmt.Sprintf("Device: %s", metadata.DeviceType))
+	}
+
+	// Language preference
+	if metadata.LanguagePreference != "" {
+		lines = append(lines, fmt.Sprintf("Language: %s", metadata.LanguagePreference))
+	}
+
+	// Entry source
+	if metadata.EntrySource != "" {
+		lines = append(lines, fmt.Sprintf("Source: %s", metadata.EntrySource))
+	}
+
+	// Client version (optional, less important)
+	if metadata.ClientVersion != "" && f.hasTokenBudget(lines, 20) {
+		lines = append(lines, fmt.Sprintf("Client: %s", metadata.ClientVersion))
+	}
+
+	// Usage statistics (optional, included only if we have token budget)
+	if f.hasTokenBudget(lines, 50) {
+		if metadata.ActiveDaysLast7 != nil || metadata.ActiveDaysLast30 != nil {
+			var stats []string
+			if metadata.ActiveDaysLast7 != nil {
+				stats = append(stats, fmt.Sprintf("active %dd/7d", *metadata.ActiveDaysLast7))
+			}
+			if metadata.ActiveDaysLast30 != nil {
+				stats = append(stats, fmt.Sprintf("%dd/30d", *metadata.ActiveDaysLast30))
+			}
+			if len(stats) > 0 {
+				lines = append(lines, fmt.Sprintf("Activity: %s", strings.Join(stats, ", ")))
+			}
+		}
+	}
+
+	lines = append(lines, "</session-metadata>")
+
+	return strings.Join(lines, "\n")
+}
+
+// formatTime formats the current time with timezone information.
+func (f *SessionMetadataFormatter) formatTime(metadata *domain.SessionMetadata) string {
+	if metadata.CurrentTime.IsZero() {
+		return ""
+	}
+
+	// Format time as: "2024-01-15 14:30 (Asia/Shanghai)" or "2024-01-15 14:30 UTC"
+	timeStr := metadata.CurrentTime.Format("2006-01-02 15:04")
+
+	if metadata.Timezone != "" {
+		return fmt.Sprintf("%s (%s)", timeStr, metadata.Timezone)
+	}
+	return fmt.Sprintf("%s UTC", timeStr)
+}
+
+// hasTokenBudget checks if we have enough token budget to add more content.
+func (f *SessionMetadataFormatter) hasTokenBudget(lines []string, additionalTokens int) bool {
+	current := f.tokenizer.CountTokens(strings.Join(lines, "\n"))
+	return current+additionalTokens < f.config.MaxTokens
+}
+
+// FormatAndValidate formats the metadata and ensures it stays within token limits.
+// If the formatted metadata exceeds the limit, it will be truncated.
+func (f *SessionMetadataFormatter) FormatAndValidate(metadata *domain.SessionMetadata) (string, error) {
+	if metadata == nil {
+		return "", nil
+	}
+
+	// Validate the metadata
+	if err := metadata.Validate(); err != nil {
+		return "", err
+	}
+
+	// Format the metadata
+	formatted := f.Format(metadata)
+
+	// Check token count
+	tokens := f.tokenizer.CountTokens(formatted)
+	if tokens > f.config.MaxTokens {
+		// Truncate by removing optional fields
+		formatted = f.formatMinimal(metadata)
+		tokens = f.tokenizer.CountTokens(formatted)
+	}
+
+	// Final check - this should rarely happen with minimal format
+	if tokens > f.config.MaxTokens {
+		return "", fmt.Errorf("session metadata exceeds maximum token limit (%d > %d)", tokens, f.config.MaxTokens)
+	}
+
+	return formatted, nil
+}
+
+// formatMinimal formats only the essential metadata fields.
+func (f *SessionMetadataFormatter) formatMinimal(metadata *domain.SessionMetadata) string {
+	var lines []string
+	lines = append(lines, "<session-metadata>")
+
+	// Only essential: time
+	timeStr := f.formatTime(metadata)
+	if timeStr != "" {
+		lines = append(lines, fmt.Sprintf("Time: %s", timeStr))
+	}
+
+	// Device type (important for response style)
+	if metadata.DeviceType != "" {
+		lines = append(lines, fmt.Sprintf("Device: %s", metadata.DeviceType))
+	}
+
+	// Language (important for localization)
+	if metadata.LanguagePreference != "" {
+		lines = append(lines, fmt.Sprintf("Language: %s", metadata.LanguagePreference))
+	}
+
+	lines = append(lines, "</session-metadata>")
+	return strings.Join(lines, "\n")
+}
+
+// CountTokens counts the tokens in the formatted metadata.
+func (f *SessionMetadataFormatter) CountTokens(metadata *domain.SessionMetadata) int {
+	formatted := f.Format(metadata)
+	return f.tokenizer.CountTokens(formatted)
+}
+
+// BuildMetadataWithContext creates a ContextMessage from session metadata.
+// The message has role "metadata" which is treated specially - always preserved
+// during truncation, similar to "memory" role.
+func BuildMetadataMessage(metadata *domain.SessionMetadata, formatter *SessionMetadataFormatter) (ContextMessage, error) {
+	if metadata == nil {
+		return ContextMessage{}, nil
+	}
+
+	content, err := formatter.FormatAndValidate(metadata)
+	if err != nil {
+		return ContextMessage{}, err
+	}
+
+	if content == "" {
+		return ContextMessage{}, nil
+	}
+
+	return ContextMessage{
+		Role:    "metadata",
+		Content: content,
+	}, nil
+}
+
+// CollectMetadataFromRequest extracts session metadata from an HTTP request.
+// This function reads from standard headers and query parameters.
+func CollectMetadataFromRequest(deviceType, timezone, language, entrySource, clientVersion string) *domain.SessionMetadata {
+	metadata := &domain.SessionMetadata{
+		CurrentTime: time.Now(),
+	}
+
+	if deviceType != "" {
+		metadata.DeviceType = deviceType
+	}
+	if timezone != "" {
+		metadata.Timezone = timezone
+	}
+	if language != "" {
+		metadata.LanguagePreference = language
+	}
+	if entrySource != "" {
+		metadata.EntrySource = entrySource
+	}
+	if clientVersion != "" {
+		metadata.ClientVersion = clientVersion
+	}
+
+	return metadata
+}
+
+// AddUsageStatistics adds optional usage statistics to the metadata.
+func AddUsageStatistics(metadata *domain.SessionMetadata, activeDays7, activeDays30 int, avgMsgLength float64, totalSessions int) *domain.SessionMetadata {
+	if metadata == nil {
+		metadata = &domain.SessionMetadata{CurrentTime: time.Now()}
+	}
+
+	if activeDays7 > 0 {
+		metadata.ActiveDaysLast7 = &activeDays7
+	}
+	if activeDays30 > 0 {
+		metadata.ActiveDaysLast30 = &activeDays30
+	}
+	if avgMsgLength > 0 {
+		metadata.AverageMessageLength = &avgMsgLength
+	}
+	if totalSessions > 0 {
+		metadata.TotalSessions = &totalSessions
+	}
+
+	return metadata
+}

--- a/server/internal/service/session_metadata_test.go
+++ b/server/internal/service/session_metadata_test.go
@@ -1,0 +1,306 @@
+package service
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devioslang/memorix/server/internal/domain"
+)
+
+func TestSessionMetadataFormatter_Format(t *testing.T) {
+	formatter := NewSessionMetadataFormatter(DefaultSessionMetadataConfig())
+
+	tests := []struct {
+		name       string
+		metadata   *domain.SessionMetadata
+		wantFields []string
+		dontWant   []string
+	}{
+		{
+			name:     "nil metadata",
+			metadata: nil,
+			wantFields: []string{},
+		},
+		{
+			name: "full metadata",
+			metadata: &domain.SessionMetadata{
+				DeviceType:          "desktop",
+				Timezone:            "Asia/Shanghai",
+				LanguagePreference:  "zh-CN",
+				CurrentTime:         time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC),
+				EntrySource:         "web",
+				ClientVersion:       "1.0.0",
+				ActiveDaysLast7:     intPtr(5),
+				ActiveDaysLast30:    intPtr(20),
+			},
+			wantFields: []string{
+				"<session-metadata>",
+				"Time:",
+				"Device: desktop",
+				"Language: zh-CN",
+				"Source: web",
+				"Client: 1.0.0",
+				"Activity:",
+				"</session-metadata>",
+			},
+		},
+		{
+			name: "minimal metadata",
+			metadata: &domain.SessionMetadata{
+				DeviceType:  "mobile",
+				CurrentTime: time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC),
+			},
+			wantFields: []string{
+				"<session-metadata>",
+				"Device: mobile",
+				"</session-metadata>",
+			},
+			dontWant: []string{"Activity:", "Client:"},
+		},
+		{
+			name: "with timezone",
+			metadata: &domain.SessionMetadata{
+				DeviceType:  "desktop",
+				Timezone:    "America/New_York",
+				CurrentTime: time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC),
+			},
+			wantFields: []string{
+				"(America/New_York)",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatter.Format(tt.metadata)
+			if tt.metadata == nil {
+				if result != "" {
+					t.Errorf("expected empty string for nil metadata, got %q", result)
+				}
+				return
+			}
+
+			for _, field := range tt.wantFields {
+				if !strings.Contains(result, field) {
+					t.Errorf("expected result to contain %q, got %q", field, result)
+				}
+			}
+
+			for _, field := range tt.dontWant {
+				if strings.Contains(result, field) {
+					t.Errorf("expected result NOT to contain %q, got %q", field, result)
+				}
+			}
+		})
+	}
+}
+
+func TestSessionMetadataFormatter_FormatAndValidate(t *testing.T) {
+	formatter := NewSessionMetadataFormatter(DefaultSessionMetadataConfig())
+
+	t.Run("valid metadata", func(t *testing.T) {
+		metadata := &domain.SessionMetadata{
+			DeviceType:         "desktop",
+			Timezone:           "Asia/Shanghai",
+			LanguagePreference: "zh-CN",
+			CurrentTime:        time.Now(),
+		}
+
+		result, err := formatter.FormatAndValidate(metadata)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if result == "" {
+			t.Error("expected non-empty result")
+		}
+	})
+
+	t.Run("invalid device type", func(t *testing.T) {
+		metadata := &domain.SessionMetadata{
+			DeviceType:  "invalid",
+			CurrentTime: time.Now(),
+		}
+
+		_, err := formatter.FormatAndValidate(metadata)
+		if err == nil {
+			t.Error("expected error for invalid device type")
+		}
+	})
+
+	t.Run("nil metadata", func(t *testing.T) {
+		result, err := formatter.FormatAndValidate(nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if result != "" {
+			t.Errorf("expected empty result for nil metadata, got %q", result)
+		}
+	})
+}
+
+func TestSessionMetadataFormatter_TokenLimit(t *testing.T) {
+	// Test that formatted metadata stays under 200 tokens
+	formatter := NewSessionMetadataFormatter(DefaultSessionMetadataConfig())
+
+	metadata := &domain.SessionMetadata{
+		DeviceType:          "desktop",
+		Timezone:            "Asia/Shanghai",
+		LanguagePreference:  "zh-CN",
+		CurrentTime:         time.Now(),
+		EntrySource:         "web",
+		ClientVersion:       "1.0.0",
+		ActiveDaysLast7:     intPtr(5),
+		ActiveDaysLast30:    intPtr(20),
+		AverageMessageLength: floatPtr(150.0),
+		TotalSessions:       intPtr(100),
+	}
+
+	result, err := formatter.FormatAndValidate(metadata)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	tokens := formatter.CountTokens(metadata)
+	if tokens > 200 {
+		t.Errorf("metadata tokens %d exceeds limit of 200", tokens)
+	}
+
+	// Also check the token count matches
+	actualTokens := formatter.tokenizer.CountTokens(result)
+	if tokens != actualTokens {
+		t.Errorf("CountTokens() = %d, want %d", tokens, actualTokens)
+	}
+}
+
+func TestBuildMetadataMessage(t *testing.T) {
+	formatter := NewSessionMetadataFormatter(DefaultSessionMetadataConfig())
+
+	t.Run("valid metadata", func(t *testing.T) {
+		metadata := &domain.SessionMetadata{
+			DeviceType:  "desktop",
+			CurrentTime: time.Now(),
+		}
+
+		msg, err := BuildMetadataMessage(metadata, formatter)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if msg.Role != "metadata" {
+			t.Errorf("expected role 'metadata', got %q", msg.Role)
+		}
+		if msg.Content == "" {
+			t.Error("expected non-empty content")
+		}
+	})
+
+	t.Run("nil metadata", func(t *testing.T) {
+		msg, err := BuildMetadataMessage(nil, formatter)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if msg.Content != "" {
+			t.Errorf("expected empty content for nil metadata, got %q", msg.Content)
+		}
+	})
+
+	t.Run("invalid metadata", func(t *testing.T) {
+		metadata := &domain.SessionMetadata{
+			DeviceType: "invalid_device_type",
+		}
+
+		_, err := BuildMetadataMessage(metadata, formatter)
+		if err == nil {
+			t.Error("expected error for invalid metadata")
+		}
+	})
+}
+
+func TestCollectMetadataFromRequest(t *testing.T) {
+	metadata := CollectMetadataFromRequest("desktop", "Asia/Shanghai", "zh-CN", "web", "1.0.0")
+
+	if metadata.DeviceType != "desktop" {
+		t.Errorf("DeviceType = %q, want 'desktop'", metadata.DeviceType)
+	}
+	if metadata.Timezone != "Asia/Shanghai" {
+		t.Errorf("Timezone = %q, want 'Asia/Shanghai'", metadata.Timezone)
+	}
+	if metadata.LanguagePreference != "zh-CN" {
+		t.Errorf("LanguagePreference = %q, want 'zh-CN'", metadata.LanguagePreference)
+	}
+	if metadata.EntrySource != "web" {
+		t.Errorf("EntrySource = %q, want 'web'", metadata.EntrySource)
+	}
+	if metadata.ClientVersion != "1.0.0" {
+		t.Errorf("ClientVersion = %q, want '1.0.0'", metadata.ClientVersion)
+	}
+	if metadata.CurrentTime.IsZero() {
+		t.Error("CurrentTime should be set")
+	}
+}
+
+func TestAddUsageStatistics(t *testing.T) {
+	t.Run("add to existing metadata", func(t *testing.T) {
+		metadata := &domain.SessionMetadata{
+			DeviceType:  "desktop",
+			CurrentTime: time.Now(),
+		}
+
+		result := AddUsageStatistics(metadata, 5, 20, 150.0, 100)
+
+		if *result.ActiveDaysLast7 != 5 {
+			t.Errorf("ActiveDaysLast7 = %d, want 5", *result.ActiveDaysLast7)
+		}
+		if *result.ActiveDaysLast30 != 20 {
+			t.Errorf("ActiveDaysLast30 = %d, want 20", *result.ActiveDaysLast30)
+		}
+		if *result.AverageMessageLength != 150.0 {
+			t.Errorf("AverageMessageLength = %f, want 150.0", *result.AverageMessageLength)
+		}
+		if *result.TotalSessions != 100 {
+			t.Errorf("TotalSessions = %d, want 100", *result.TotalSessions)
+		}
+	})
+
+	t.Run("add to nil metadata", func(t *testing.T) {
+		result := AddUsageStatistics(nil, 5, 20, 150.0, 100)
+
+		if result == nil {
+			t.Error("expected non-nil result")
+		}
+		if *result.ActiveDaysLast7 != 5 {
+			t.Errorf("ActiveDaysLast7 = %d, want 5", *result.ActiveDaysLast7)
+		}
+	})
+
+	t.Run("add zero values should not set fields", func(t *testing.T) {
+		metadata := &domain.SessionMetadata{
+			DeviceType:  "desktop",
+			CurrentTime: time.Now(),
+		}
+
+		result := AddUsageStatistics(metadata, 0, 0, 0, 0)
+
+		if result.ActiveDaysLast7 != nil {
+			t.Errorf("ActiveDaysLast7 should be nil for zero value")
+		}
+		if result.ActiveDaysLast30 != nil {
+			t.Errorf("ActiveDaysLast30 should be nil for zero value")
+		}
+		if result.AverageMessageLength != nil {
+			t.Errorf("AverageMessageLength should be nil for zero value")
+		}
+		if result.TotalSessions != nil {
+			t.Errorf("TotalSessions should be nil for zero value")
+		}
+	})
+}
+
+// Helper functions
+func intPtr(i int) *int {
+	return &i
+}
+
+func floatPtr(f float64) *float64 {
+	return &f
+}


### PR DESCRIPTION
## Summary

- Add session metadata support for collecting transient context information at the start of each session and injecting it into system prompts
- Implement `SessionMetadata` domain model with device type, timezone, language, current time, entry source, and optional usage statistics
- Add `SessionMetadataFormatter` service for formatting metadata with token limit enforcement (< 200 tokens per acceptance criteria)
- Update `ContextWindow` to support "metadata" role that is never truncated during context window truncation
- Update context window handler to accept `session_metadata` field in API requests

## Key Changes

### Domain Model (`server/internal/domain/session_metadata.go`)
- `SessionMetadata` struct with all required and optional fields
- Validation for device type field
- `SessionMetadataFromHeaders` helper for extracting metadata from HTTP headers

### Service Layer (`server/internal/service/session_metadata.go`)
- `SessionMetadataFormatter` with token counting and limit enforcement
- `BuildMetadataMessage` for creating context messages with "metadata" role
- `CollectMetadataFromRequest` and `AddUsageStatistics` helpers

### Context Window Updates
- New "metadata" role that is preserved during truncation (like "system" and "memory")
- Message order: `system -> metadata -> memory -> conversation`
- Configurable `MetadataReservedTokens` (default 200)

## Verification Steps

1. Run `make build` - compiles successfully ✓
2. Run `make test` - all tests pass ✓
3. Run `make vet` - no issues ✓

## Test Plan

- [x] Unit tests for `SessionMetadata.Validate()`
- [x] Unit tests for `SessionMetadataFromHeaders()`
- [x] Unit tests for `SessionMetadataFormatter.Format()`
- [x] Unit tests for `SessionMetadataFormatter.FormatAndValidate()`
- [x] Token limit enforcement tests
- [x] `BuildMetadataMessage` tests
- [x] `CollectMetadataFromRequest` tests
- [x] `AddUsageStatistics` tests

Closes #3