### PR TITLE
feat: implement LLM-driven Memory Extractor

### DIFF
--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -122,6 +122,7 @@ type resolvedSvc struct {
 	memory      *service.MemoryService
 	ingest      *service.IngestService
 	userProfile *service.UserProfileService
+	extractor   *service.ExtractorService
 }
 
 type tenantSvcKey string
@@ -135,10 +136,12 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 		}
 		memRepo := tidb.NewMemoryRepo(auth.TenantDB, s.autoModel, s.ftsEnabled)
 		factRepo := tidb.NewUserProfileFactRepo(auth.TenantDB)
+		userProf := service.NewUserProfileService(factRepo, s.maxFactsPerUser)
 		svc := resolvedSvc{
 			memory:      service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
 			ingest:      service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
-			userProfile: service.NewUserProfileService(factRepo, s.maxFactsPerUser),
+			userProfile: userProf,
+			extractor:   service.NewExtractorService(factRepo, s.llmClient, userProf),
 		}
 		s.svcCache.Store(key, svc)
 		return svc
@@ -149,10 +152,12 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 	}
 	memRepo := tidb.NewMemoryRepo(auth.TenantDB, s.autoModel, s.ftsEnabled)
 	factRepo := tidb.NewUserProfileFactRepo(auth.TenantDB)
+	userProf := service.NewUserProfileService(factRepo, s.maxFactsPerUser)
 	svc := resolvedSvc{
 		memory:      service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
 		ingest:      service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
-		userProfile: service.NewUserProfileService(factRepo, s.maxFactsPerUser),
+		userProfile: userProf,
+		extractor:   service.NewExtractorService(factRepo, s.llmClient, userProf),
 	}
 	s.svcCache.Store(key, svc)
 	return svc
@@ -161,6 +166,11 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 // resolveUserProfileServices returns the UserProfileService for a request.
 func (s *Server) resolveUserProfileServices(auth *domain.AuthInfo) *service.UserProfileService {
 	return s.resolveServices(auth).userProfile
+}
+
+// resolveExtractorServices returns the ExtractorService for a request.
+func (s *Server) resolveExtractorServices(auth *domain.AuthInfo) *service.ExtractorService {
+	return s.resolveServices(auth).extractor
 }
 
 // Router builds the chi router with all routes and middleware.
@@ -209,6 +219,9 @@ func (s *Server) Router(tenantMW, rateLimitMW func(http.Handler) http.Handler) h
 		r.Get("/user-profile/facts/{id}", s.getFact)
 		r.Put("/user-profile/facts/{id}", s.updateFact)
 		r.Delete("/user-profile/facts/{id}", s.deleteFact)
+
+		// Memory Extraction (LLM-driven fact extraction from conversation).
+		r.Post("/user-profile/extract", s.extractFacts)
 
 	})
 

--- a/server/internal/handler/user_profile.go
+++ b/server/internal/handler/user_profile.go
@@ -180,3 +180,39 @@ func (s *Server) deleteFact(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusNoContent)
 }
+
+// extractFactsRequest is the request body for extracting facts from conversation.
+type extractFactsRequest struct {
+	Messages  []service.IngestMessage `json:"messages"`
+	UserID    string                  `json:"user_id"`
+	SessionID string                  `json:"session_id,omitempty"`
+}
+
+// extractFacts handles POST /user-profile/extract
+// It extracts structured facts from conversation content using LLM.
+func (s *Server) extractFacts(w http.ResponseWriter, r *http.Request) {
+	var req extractFactsRequest
+	if err := decode(r, &req); err != nil {
+		s.handleError(w, err)
+		return
+	}
+
+	auth := authInfo(r)
+	svc := s.resolveExtractorServices(auth)
+
+	extractReq := service.ExtractRequest{
+		Messages:  req.Messages,
+		UserID:    req.UserID,
+		SessionID: req.SessionID,
+	}
+
+	// Run extraction synchronously for now
+	// Can be made async if needed for large conversations
+	result, err := svc.Extract(r.Context(), extractReq)
+	if err != nil {
+		s.handleError(w, err)
+		return
+	}
+
+	respond(w, http.StatusOK, result)
+}

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -87,4 +87,12 @@ type UserProfileFactRepo interface {
 
 	// TouchLastAccessed updates the last_accessed_at timestamp for a fact.
 	TouchLastAccessed(ctx context.Context, factID string) error
+
+	// GetByKey retrieves a fact by user_id, category, and key.
+	// Returns ErrNotFound if no matching fact exists.
+	GetByKey(ctx context.Context, userID string, category domain.FactCategory, key string) (*domain.UserProfileFact, error)
+
+	// SearchByValue performs a fuzzy search for facts with similar values.
+	// Returns facts where the value is similar to the query (used for deduplication).
+	SearchByValue(ctx context.Context, userID string, value string, limit int) ([]domain.UserProfileFact, error)
 }

--- a/server/internal/repository/tidb/user_profile.go
+++ b/server/internal/repository/tidb/user_profile.go
@@ -230,6 +230,47 @@ func (r *UserProfileFactRepo) TouchLastAccessed(ctx context.Context, factID stri
 	return nil
 }
 
+// GetByKey retrieves a fact by user_id, category, and key.
+// Returns ErrNotFound if no matching fact exists.
+func (r *UserProfileFactRepo) GetByKey(ctx context.Context, userID string, category domain.FactCategory, key string) (*domain.UserProfileFact, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT `+factAllColumns+` FROM user_profile_facts WHERE user_id = ? AND category = ? AND `+"`key`"+` = ?`,
+		userID, string(category), key,
+	)
+	return scanUserProfileFact(row)
+}
+
+// SearchByValue performs a fuzzy search for facts with similar values.
+// Uses LIKE for basic text similarity matching.
+// Returns facts where the value contains similar text (used for deduplication).
+func (r *UserProfileFactRepo) SearchByValue(ctx context.Context, userID string, value string, limit int) ([]domain.UserProfileFact, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+
+	// Use LIKE with wildcards for basic fuzzy matching
+	// Also search for facts where the value contains key terms from the input
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT `+factAllColumns+` FROM user_profile_facts
+		 WHERE user_id = ? AND (
+		   value LIKE ? OR
+		   ? LIKE CONCAT('%', value, '%')
+		 )
+		 ORDER BY updated_at DESC
+		 LIMIT ?`,
+		userID,
+		"%"+value+"%",
+		value,
+		limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("search user facts by value: %w", err)
+	}
+	defer rows.Close()
+
+	return scanUserProfileFacts(rows)
+}
+
 func (r *UserProfileFactRepo) buildFilterConds(f domain.UserProfileFactFilter) ([]string, []any) {
 	conds := []string{}
 	args := []any{}

--- a/server/internal/service/extractor.go
+++ b/server/internal/service/extractor.go
@@ -1,0 +1,714 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/devioslang/memorix/server/internal/domain"
+	"github.com/devioslang/memorix/server/internal/llm"
+	"github.com/devioslang/memorix/server/internal/repository"
+)
+
+// LLMClient is an interface for LLM completion services.
+// The llm.Client struct satisfies this interface.
+type LLMClient interface {
+	Complete(ctx context.Context, system, user string) (string, error)
+	CompleteJSON(ctx context.Context, system, user string) (string, error)
+}
+
+// ExtractorService extracts structured facts from conversation content.
+// It implements the LLM-driven Memory Extractor described in Issue #5.
+type ExtractorService struct {
+	facts     repository.UserProfileFactRepo
+	llm       LLMClient
+	userProf  *UserProfileService
+}
+
+// NewExtractorService creates a new ExtractorService.
+func NewExtractorService(
+	facts repository.UserProfileFactRepo,
+	llmClient LLMClient,
+	userProf *UserProfileService,
+) *ExtractorService {
+	return &ExtractorService{
+		facts:    facts,
+		llm:      llmClient,
+		userProf: userProf,
+	}
+}
+
+// ExtractedFact represents a single extracted fact from conversation.
+type ExtractedFact struct {
+	Category   domain.FactCategory `json:"category"`
+	Key        string              `json:"key"`
+	Value      string              `json:"value"`
+	Confidence float64             `json:"confidence"`
+	Source     domain.FactSource   `json:"source"` // explicit or inferred
+}
+
+// ExtractRequest contains the input for the extraction pipeline.
+type ExtractRequest struct {
+	Messages  []IngestMessage `json:"messages"`
+	UserID    string          `json:"user_id"`
+	SessionID string          `json:"session_id,omitempty"`
+}
+
+// ExtractResult contains the result of the extraction pipeline.
+type ExtractResult struct {
+	Status       string          `json:"status"` // complete | partial | failed
+	FactsAdded   int             `json:"facts_added"`
+	FactsUpdated int             `json:"facts_updated"`
+	FactsSkipped int             `json:"facts_skipped"`
+	FactIDs      []string        `json:"fact_ids,omitempty"`
+	Warnings     int             `json:"warnings,omitempty"`
+	Error        string          `json:"error,omitempty"`
+}
+
+// Extract runs the full extraction pipeline:
+// 1. Detect explicit triggers in user messages
+// 2. Run LLM-based extraction for remaining content
+// 3. Deduplicate against existing facts
+// 4. Write new/updated facts to the User Profile Store
+func (s *ExtractorService) Extract(ctx context.Context, req ExtractRequest) (*ExtractResult, error) {
+	slog.Info("extractor pipeline started", "user_id", req.UserID, "messages", len(req.Messages))
+
+	if req.UserID == "" {
+		return nil, &domain.ValidationError{Field: "user_id", Message: "required"}
+	}
+	if len(req.Messages) == 0 {
+		return nil, &domain.ValidationError{Field: "messages", Message: "required"}
+	}
+
+	// If no LLM, we can only do explicit trigger detection
+	if s.llm == nil {
+		return s.extractExplicitOnly(ctx, req)
+	}
+
+	// Strip previously injected memory context from messages
+	cleaned := stripInjectedContext(req.Messages)
+
+	// Format conversation for LLM
+	conversation := formatConversation(cleaned)
+	if conversation == "" {
+		return &ExtractResult{Status: "complete"}, nil
+	}
+
+	// Phase 1: Detect explicit triggers and extract facts from them
+	explicitFacts := s.detectExplicitTriggers(cleaned)
+	slog.Info("explicit triggers detected", "count", len(explicitFacts))
+
+	// Phase 2: Run LLM-based extraction for implicit facts
+	implicitFacts, err := s.extractImplicitFacts(ctx, conversation)
+	if err != nil {
+		slog.Error("implicit extraction failed", "err", err)
+		// Continue with explicit facts only
+		if len(explicitFacts) == 0 {
+			return &ExtractResult{Status: "failed", Error: err.Error(), Warnings: 1}, nil
+		}
+	}
+	slog.Info("implicit facts extracted", "count", len(implicitFacts))
+
+	// Merge facts (explicit facts take precedence for same key)
+	allFacts := s.mergeFacts(explicitFacts, implicitFacts)
+
+	// Phase 3: Deduplicate and write facts
+	result, err := s.dedupAndWrite(ctx, req.UserID, allFacts)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// extractExplicitOnly handles extraction when LLM is not available.
+func (s *ExtractorService) extractExplicitOnly(ctx context.Context, req ExtractRequest) (*ExtractResult, error) {
+	cleaned := stripInjectedContext(req.Messages)
+	explicitFacts := s.detectExplicitTriggers(cleaned)
+
+	if len(explicitFacts) == 0 {
+		return &ExtractResult{Status: "complete"}, nil
+	}
+
+	return s.dedupAndWrite(ctx, req.UserID, explicitFacts)
+}
+
+// ExplicitTriggerPattern represents a pattern for detecting explicit memory commands.
+type ExplicitTriggerPattern struct {
+	Pattern     *regexp.Regexp
+	Category    domain.FactCategory
+	KeyExtractor func(matches []string) string
+}
+
+var explicitTriggerPatterns = []ExplicitTriggerPattern{
+	// Chinese patterns - ORDER MATTERS: more specific patterns first
+	// "记住我喜欢xxx" or "记住我爱xxx" - MUST be before generic "记住" patterns
+	{
+		Pattern:  regexp.MustCompile(`(?i)^记住\s*(?:我)?(喜欢|爱|偏好)\s*(.+)$`),
+		Category: domain.CategoryPreference,
+		KeyExtractor: func(m []string) string {
+			return "likes"
+		},
+	},
+	{
+		// "记住我不喜欢xxx" or "记住我讨厌xxx"
+		Pattern:  regexp.MustCompile(`(?i)^记住\s*(?:我)?(不喜欢|讨厌|厌恶)\s*(.+)$`),
+		Category: domain.CategoryPreference,
+		KeyExtractor: func(m []string) string {
+			return "dislikes"
+		},
+	},
+	{
+		// "记住我叫张三" or "记住我的名字是张三"
+		Pattern:  regexp.MustCompile(`(?i)^记住\s*(?:我|我的)?(?:名字|叫)?\s*(?:是)?\s*(.+)$`),
+		Category: domain.CategoryPersonal,
+		KeyExtractor: func(m []string) string {
+			return "name"
+		},
+	},
+	{
+		// "记住我的邮箱是xxx" or "记住我的email是xxx"
+		Pattern:  regexp.MustCompile(`(?i)^记住\s*(?:我|我的)?(?:邮箱|email|e-mail)\s*(?:是)?\s*(.+)$`),
+		Category: domain.CategoryPersonal,
+		KeyExtractor: func(m []string) string {
+			return "email"
+		},
+	},
+	{
+		// "记住我的电话是xxx" or "记住我的手机号是xxx"
+		Pattern:  regexp.MustCompile(`(?i)^记住\s*(?:我|我的)?(?:电话|手机|手机号)\s*(?:是)?\s*(.+)$`),
+		Category: domain.CategoryPersonal,
+		KeyExtractor: func(m []string) string {
+			return "phone"
+		},
+	},
+	{
+		// "记住我是xxx工程师" or "记住我的职业是xxx"
+		Pattern:  regexp.MustCompile(`(?i)^记住\s*(?:我|我的)?(?:职业|工作|职位)\s*(?:是)?\s*(.+)$`),
+		Category: domain.CategoryPersonal,
+		KeyExtractor: func(m []string) string {
+			return "occupation"
+		},
+	},
+	{
+		// "记住我的目标是xxx" or "记住我想xxx"
+		Pattern:  regexp.MustCompile(`(?i)^记住\s*(?:我|我的)?(?:目标|想|想要)\s*(?:是)?\s*(.+)$`),
+		Category: domain.CategoryGoal,
+		KeyExtractor: func(m []string) string {
+			return "goal"
+		},
+	},
+	{
+		// "记住我会xxx" or "记住我擅长xxx" or "记住我的技能是xxx"
+		Pattern:  regexp.MustCompile(`(?i)^记住\s*(?:我|我的)?(?:会|擅长|技能)\s*(.+)$`),
+		Category: domain.CategorySkill,
+		KeyExtractor: func(m []string) string {
+			return "skill"
+		},
+	},
+	// Generic "记住xxx" pattern (catch-all for other explicit commands)
+	{
+		Pattern:  regexp.MustCompile(`(?i)^记住\s+(.+)$`),
+		Category: domain.CategoryPersonal,
+		KeyExtractor: func(m []string) string {
+			return "fact"
+		},
+	},
+	// English patterns
+	{
+		// "remember my name is xxx"
+		Pattern:  regexp.MustCompile(`(?i)^remember\s+(?:my\s+)?name\s+(?:is\s+)?(.+)$`),
+		Category: domain.CategoryPersonal,
+		KeyExtractor: func(m []string) string {
+			return "name"
+		},
+	},
+	{
+		// "remember my email is xxx"
+		Pattern:  regexp.MustCompile(`(?i)^remember\s+(?:my\s+)?(?:email|e-mail)\s+(?:is\s+)?(.+)$`),
+		Category: domain.CategoryPersonal,
+		KeyExtractor: func(m []string) string {
+			return "email"
+		},
+	},
+	{
+		// "remember I like xxx" or "remember I love xxx"
+		Pattern:  regexp.MustCompile(`(?i)^remember\s+(?:I\s+)?(like|love|prefer)\s+(.+)$`),
+		Category: domain.CategoryPreference,
+		KeyExtractor: func(m []string) string {
+			return "likes"
+		},
+	},
+	{
+		// "remember I dislike xxx" or "remember I hate xxx"
+		Pattern:  regexp.MustCompile(`(?i)^remember\s+(?:I\s+)?(dislike|hate)\s+(.+)$`),
+		Category: domain.CategoryPreference,
+		KeyExtractor: func(m []string) string {
+			return "dislikes"
+		},
+	},
+	// "我的xxx是xxx" patterns (Chinese "my xxx is xxx")
+	{
+		Pattern:  regexp.MustCompile(`^(?:我|我的)(?:名字|姓名)\s*(?:是|=)?\s*(.+)$`),
+		Category: domain.CategoryPersonal,
+		KeyExtractor: func(m []string) string {
+			return "name"
+		},
+	},
+	{
+		Pattern:  regexp.MustCompile(`^(?:我|我的)(?:邮箱|email|e-mail)\s*(?:是|=)?\s*(.+)$`),
+		Category: domain.CategoryPersonal,
+		KeyExtractor: func(m []string) string {
+			return "email"
+		},
+	},
+	{
+		Pattern:  regexp.MustCompile(`^(?:我|我的)(?:职业|工作|职位)\s*(?:是|=)?\s*(.+)$`),
+		Category: domain.CategoryPersonal,
+		KeyExtractor: func(m []string) string {
+			return "occupation"
+		},
+	},
+	{
+		Pattern:  regexp.MustCompile(`^(?:我|我的)(?:公司|单位)\s*(?:是|=)?\s*(.+)$`),
+		Category: domain.CategoryPersonal,
+		KeyExtractor: func(m []string) string {
+			return "company"
+		},
+	},
+	{
+		Pattern:  regexp.MustCompile(`^(?:我|我的)(?:目标)\s*(?:是|=)?\s*(.+)$`),
+		Category: domain.CategoryGoal,
+		KeyExtractor: func(m []string) string {
+			return "goal"
+		},
+	},
+	{
+		Pattern:  regexp.MustCompile(`^(?:我)(?:会|擅长|精通)\s*(.+)$`),
+		Category: domain.CategorySkill,
+		KeyExtractor: func(m []string) string {
+			return "skill"
+		},
+	},
+	{
+		Pattern:  regexp.MustCompile(`^(?:我)(?:喜欢|爱)\s*(.+)$`),
+		Category: domain.CategoryPreference,
+		KeyExtractor: func(m []string) string {
+			return "likes"
+		},
+	},
+	{
+		Pattern:  regexp.MustCompile(`^(?:我)(?:不喜欢|讨厌)\s*(.+)$`),
+		Category: domain.CategoryPreference,
+		KeyExtractor: func(m []string) string {
+			return "dislikes"
+		},
+	},
+	// "我是xxx" pattern for occupation/role
+	{
+		Pattern:  regexp.MustCompile(`^我是\s*(.+)$`),
+		Category: domain.CategoryPersonal,
+		KeyExtractor: func(m []string) string {
+			return "occupation"
+		},
+	},
+}
+
+// detectExplicitTriggers scans user messages for explicit memory commands.
+func (s *ExtractorService) detectExplicitTriggers(messages []IngestMessage) []ExtractedFact {
+	var facts []ExtractedFact
+
+	for _, msg := range messages {
+		// Only process user messages
+		if strings.ToLower(msg.Role) != "user" {
+			continue
+		}
+
+		content := strings.TrimSpace(msg.Content)
+		if content == "" {
+			continue
+		}
+
+		for _, pattern := range explicitTriggerPatterns {
+			matches := pattern.Pattern.FindStringSubmatch(content)
+			if matches == nil {
+				continue
+			}
+
+			// Extract the value from matches
+			var value string
+			if len(matches) >= 2 {
+				// For patterns with 2 capture groups (e.g., "remember I like xxx")
+				if len(matches) >= 3 && matches[2] != "" {
+					value = strings.TrimSpace(matches[2])
+				} else {
+					value = strings.TrimSpace(matches[len(matches)-1])
+				}
+			}
+
+			if value == "" {
+				continue
+			}
+
+			key := pattern.KeyExtractor(matches)
+
+			facts = append(facts, ExtractedFact{
+				Category:   pattern.Category,
+				Key:        key,
+				Value:      value,
+				Confidence: 1.0, // Explicit facts have full confidence
+				Source:     domain.SourceExplicit,
+			})
+
+			// Only match first pattern per message to avoid duplicates
+			break
+		}
+	}
+
+	return facts
+}
+
+// extractImplicitFacts uses LLM to extract structured facts from conversation.
+func (s *ExtractorService) extractImplicitFacts(ctx context.Context, conversation string) ([]ExtractedFact, error) {
+	currentDate := time.Now().Format("2006-01-02")
+
+	systemPrompt := `You are an information extraction engine. Your task is to extract structured facts about the user from a conversation and return them as a JSON array.
+
+## Categories
+
+Use one of these categories for each fact:
+- "personal": Personal information (name, age, location, occupation, contact info, family, etc.)
+- "preference": User preferences (likes, dislikes, favorites, preferred styles, etc.)
+- "goal": User goals and objectives (what they want to achieve, learn, or accomplish)
+- "skill": User skills and expertise (what they know, can do, or are learning)
+
+## Rules
+
+1. Extract facts ONLY from the user's messages. Ignore assistant and system messages entirely.
+2. Each fact must have: category, key (a short identifier like "name", "language_preference"), value (the actual fact), and confidence (0.0-1.0).
+3. Keys should be in English snake_case format.
+4. Preserve the user's original language in the value field.
+5. Confidence should be:
+   - 1.0 for explicit statements (e.g., "My name is John")
+   - 0.8-0.9 for strong implicit signals (e.g., "I've been working with Python for 10 years" → skill)
+   - 0.5-0.7 for weaker inferences (e.g., "I hate debugging" → preference)
+6. Omit ephemeral information, greetings, task-specific details with no future value.
+7. If no meaningful facts exist, return an empty array.
+
+## Examples
+
+Input:
+User: Hi, I'm Sarah, a product manager at a tech startup.
+Assistant: Hello Sarah! How can I help you today?
+Output: {"facts": [{"category": "personal", "key": "name", "value": "Sarah", "confidence": 1.0}, {"category": "personal", "key": "occupation", "value": "product manager at a tech startup", "confidence": 1.0}]}
+
+Input:
+User: I'm trying to learn Rust, but it's been challenging. I've been a Python developer for 8 years.
+Assistant: Rust has a steep learning curve. Your Python background will help with some concepts.
+Output: {"facts": [{"category": "skill", "key": "learning", "value": "Rust", "confidence": 1.0}, {"category": "skill", "key": "programming_language", "value": "Python (8 years experience)", "confidence": 1.0}]}
+
+Input:
+User: I prefer dark mode for everything, especially in my IDE.
+Assistant: Dark mode is easier on the eyes!
+Output: {"facts": [{"category": "preference", "key": "ui_theme", "value": "dark mode", "confidence": 1.0}]}
+
+Input:
+User: 我是后端工程师，主要用 Python 和 Go。
+Assistant: 您好！有什么可以帮助您的？
+Output: {"facts": [{"category": "personal", "key": "occupation", "value": "后端工程师", "confidence": 1.0}, {"category": "skill", "key": "programming_language", "value": "Python 和 Go", "confidence": 1.0}]}
+
+## Output Format
+
+Return ONLY valid JSON. No markdown fences, no explanation.
+
+{"facts": [{"category": "...", "key": "...", "value": "...", "confidence": 0.0}, ...]}`
+
+	userPrompt := fmt.Sprintf("Extract structured facts about the user from this conversation. Today's date is %s.\n\n%s", currentDate, conversation)
+
+	raw, err := s.llm.CompleteJSON(ctx, systemPrompt, userPrompt)
+	if err != nil {
+		return nil, fmt.Errorf("extraction LLM call: %w", err)
+	}
+
+	type llmExtractedFact struct {
+		Category   string  `json:"category"`
+		Key        string  `json:"key"`
+		Value      string  `json:"value"`
+		Confidence float64 `json:"confidence"`
+	}
+	type extractResponse struct {
+		Facts []llmExtractedFact `json:"facts"`
+	}
+
+	parsed, err := llm.ParseJSON[extractResponse](raw)
+	if err != nil {
+		// Retry once without JSON format requirement
+		raw2, retryErr := s.llm.CompleteJSON(ctx, systemPrompt,
+			"Your previous response was not valid JSON. Return ONLY the JSON object.\n\n"+userPrompt)
+		if retryErr != nil {
+			return nil, fmt.Errorf("extraction retry: %w", retryErr)
+		}
+		parsed, err = llm.ParseJSON[extractResponse](raw2)
+		if err != nil {
+			return nil, fmt.Errorf("extraction parse after retry: %w", err)
+		}
+	}
+
+	// Convert to ExtractedFact and validate
+	var facts []ExtractedFact
+	for _, f := range parsed.Facts {
+		// Validate and normalize category
+		cat := domain.FactCategory(strings.ToLower(f.Category))
+		if !domain.IsValidCategory(cat) {
+			cat = domain.CategoryPersonal // Default to personal
+		}
+
+		// Validate confidence
+		conf := f.Confidence
+		if conf < 0 {
+			conf = 0
+		}
+		if conf > 1 {
+			conf = 1
+		}
+
+		// Clean up key and value
+		key := strings.TrimSpace(strings.ToLower(f.Key))
+		value := strings.TrimSpace(f.Value)
+
+		if key == "" || value == "" {
+			continue
+		}
+
+		facts = append(facts, ExtractedFact{
+			Category:   cat,
+			Key:        key,
+			Value:      value,
+			Confidence: conf,
+			Source:     domain.SourceInferred,
+		})
+	}
+
+	slog.Info("implicit facts extracted", "count", len(facts))
+	return facts, nil
+}
+
+// mergeFacts combines explicit and implicit facts, with explicit taking precedence.
+func (s *ExtractorService) mergeFacts(explicit, implicit []ExtractedFact) []ExtractedFact {
+	// Build a map of explicit facts by (category, key)
+	explicitMap := make(map[string]ExtractedFact)
+	for _, f := range explicit {
+		key := fmt.Sprintf("%s:%s", f.Category, f.Key)
+		explicitMap[key] = f
+	}
+
+	// Add implicit facts that don't conflict with explicit ones
+	var result []ExtractedFact
+	for _, f := range explicit {
+		result = append(result, f)
+	}
+	for _, f := range implicit {
+		key := fmt.Sprintf("%s:%s", f.Category, f.Key)
+		if _, exists := explicitMap[key]; !exists {
+			result = append(result, f)
+		}
+	}
+
+	return result
+}
+
+// dedupAndWrite checks for duplicates and writes facts to the User Profile Store.
+// Deduplication rules:
+// 1. Exact match on (user_id, category, key) → update existing fact
+// 2. Similar value (text similarity) → skip to avoid duplicates
+func (s *ExtractorService) dedupAndWrite(ctx context.Context, userID string, facts []ExtractedFact) (*ExtractResult, error) {
+	result := &ExtractResult{Status: "complete"}
+	var factIDs []string
+	var warnings int
+
+	for _, fact := range facts {
+		// Check for exact match on (category, key)
+		existing, err := s.facts.GetByKey(ctx, userID, fact.Category, fact.Key)
+		if err != nil && err != domain.ErrNotFound {
+			slog.Warn("failed to check existing fact", "err", err, "key", fact.Key)
+			warnings++
+			continue
+		}
+
+		if existing != nil {
+			// Exact match found - update if value is different or confidence is higher
+			if existing.Value == fact.Value {
+				// Same value - just update timestamp
+				result.FactsSkipped++
+				slog.Debug("skipping duplicate fact", "key", fact.Key, "value", fact.Value)
+				continue
+			}
+
+			// Check for similar values (basic dedup)
+			if s.isSimilarValue(existing.Value, fact.Value) {
+				result.FactsSkipped++
+				slog.Debug("skipping similar fact", "key", fact.Key, "existing", existing.Value, "new", fact.Value)
+				continue
+			}
+
+			// Update the existing fact
+			updateInput := UpdateFactInput{
+				Value:      &fact.Value,
+				Confidence: &fact.Confidence,
+				Source:     &fact.Source,
+			}
+			updated, err := s.userProf.UpdateFact(ctx, existing.FactID, updateInput)
+			if err != nil {
+				slog.Warn("failed to update fact", "err", err, "fact_id", existing.FactID)
+				warnings++
+				continue
+			}
+			result.FactsUpdated++
+			factIDs = append(factIDs, updated.FactID)
+			slog.Info("updated fact", "key", fact.Key, "value", fact.Value)
+			continue
+		}
+
+		// Check for similar values in same category
+		similar, err := s.facts.SearchByValue(ctx, userID, fact.Value, 5)
+		shouldSkip := false
+		if err != nil {
+			slog.Warn("failed to search similar facts", "err", err)
+			// Continue anyway
+		} else if len(similar) > 0 {
+			// Check similarity threshold
+			for _, sim := range similar {
+				if sim.Category == fact.Category && sim.Value == fact.Value {
+					shouldSkip = true
+					slog.Debug("skipping duplicate fact found via value search", "key", fact.Key)
+					break
+				}
+				// Check if values are very similar (> 90% overlap)
+				if sim.Category == fact.Category && s.isSimilarValue(sim.Value, fact.Value) {
+					shouldSkip = true
+					slog.Debug("skipping similar fact found via value search", "key", fact.Key)
+					break
+				}
+			}
+		}
+
+		if shouldSkip {
+			result.FactsSkipped++
+			continue
+		}
+
+		// Create new fact
+		createInput := CreateFactInput{
+			UserID:     userID,
+			Category:   fact.Category,
+			Key:        fact.Key,
+			Value:      fact.Value,
+			Confidence: fact.Confidence,
+			Source:     fact.Source,
+		}
+		created, err := s.userProf.CreateFact(ctx, createInput)
+		if err != nil {
+			slog.Warn("failed to create fact", "err", err, "key", fact.Key)
+			warnings++
+			continue
+		}
+		result.FactsAdded++
+		factIDs = append(factIDs, created.FactID)
+		slog.Info("created fact", "key", fact.Key, "value", fact.Value, "category", fact.Category)
+	}
+
+	result.FactIDs = factIDs
+	result.Warnings = warnings
+
+	if warnings > 0 && result.FactsAdded+result.FactsUpdated == 0 {
+		result.Status = "failed"
+	} else if warnings > 0 {
+		result.Status = "partial"
+	}
+
+	return result, nil
+}
+
+// isSimilarValue checks if two values are similar (> 90% overlap).
+// This is a simple implementation using string comparison.
+// A more sophisticated implementation would use embeddings for semantic similarity.
+func (s *ExtractorService) isSimilarValue(a, b string) bool {
+	a = strings.ToLower(strings.TrimSpace(a))
+	b = strings.ToLower(strings.TrimSpace(b))
+
+	if a == b {
+		return true
+	}
+
+	// Simple containment check
+	if strings.Contains(a, b) || strings.Contains(b, a) {
+		// Calculate overlap ratio
+		shorter := a
+		if len(b) < len(a) {
+			shorter = b
+		}
+		longer := b
+		if len(a) > len(b) {
+			longer = a
+		}
+
+		// If shorter is contained in longer and the ratio is > 0.9
+		ratio := float64(len(shorter)) / float64(len(longer))
+		return ratio > 0.9
+	}
+
+	return false
+}
+
+// HasLLM returns true if an LLM client is configured.
+func (s *ExtractorService) HasLLM() bool {
+	return s.llm != nil
+}
+
+// ExtractFromContent extracts facts from a single content string.
+// This is a convenience method for extracting facts without a full conversation.
+func (s *ExtractorService) ExtractFromContent(ctx context.Context, userID, content string) (*ExtractResult, error) {
+	if content == "" {
+		return nil, &domain.ValidationError{Field: "content", Message: "required"}
+	}
+
+	return s.Extract(ctx, ExtractRequest{
+		Messages: []IngestMessage{{Role: "user", Content: content}},
+		UserID:   userID,
+	})
+}
+
+// GetExplicitTriggerPatterns returns the list of explicit trigger patterns for testing.
+func GetExplicitTriggerPatterns() []ExplicitTriggerPattern {
+	return explicitTriggerPatterns
+}
+
+// NormalizeFactKey normalizes a fact key for consistent storage.
+func NormalizeFactKey(key string) string {
+	key = strings.ToLower(strings.TrimSpace(key))
+	// Replace spaces and special chars with underscores
+	key = regexp.MustCompile(`[^a-z0-9_]+`).ReplaceAllString(key, "_")
+	// Remove leading/trailing underscores
+	key = strings.Trim(key, "_")
+	return key
+}
+
+// init registers the custom JSON marshaler for ExtractResult.
+func init() {
+	// Ensure JSON marshaling works correctly
+	var _ json.Marshaler = (*ExtractResult)(nil)
+}
+
+// MarshalJSON ensures ExtractResult marshals correctly.
+func (r ExtractResult) MarshalJSON() ([]byte, error) {
+	type Alias ExtractResult
+	return json.Marshal(struct {
+		Alias
+	}{
+		Alias: Alias(r),
+	})
+}

--- a/server/internal/service/extractor_test.go
+++ b/server/internal/service/extractor_test.go
@@ -1,0 +1,678 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/devioslang/memorix/server/internal/domain"
+	"github.com/devioslang/memorix/server/internal/llm"
+)
+
+// mockFactRepo implements repository.UserProfileFactRepo for testing.
+type mockFactRepo struct {
+	facts        map[string]*domain.UserProfileFact
+	getByKeyFunc func(ctx context.Context, userID string, category domain.FactCategory, key string) (*domain.UserProfileFact, error)
+	searchFunc   func(ctx context.Context, userID string, value string, limit int) ([]domain.UserProfileFact, error)
+	createFunc   func(ctx context.Context, fact *domain.UserProfileFact) error
+	updateFunc   func(ctx context.Context, fact *domain.UserProfileFact) error
+}
+
+func newMockFactRepo() *mockFactRepo {
+	return &mockFactRepo{
+		facts: make(map[string]*domain.UserProfileFact),
+	}
+}
+
+func (m *mockFactRepo) Create(ctx context.Context, fact *domain.UserProfileFact) error {
+	if m.createFunc != nil {
+		return m.createFunc(ctx, fact)
+	}
+	m.facts[fact.FactID] = fact
+	return nil
+}
+
+func (m *mockFactRepo) GetByID(ctx context.Context, factID string) (*domain.UserProfileFact, error) {
+	fact, ok := m.facts[factID]
+	if !ok {
+		return nil, domain.ErrNotFound
+	}
+	return fact, nil
+}
+
+func (m *mockFactRepo) GetByUserID(ctx context.Context, userID string) ([]domain.UserProfileFact, error) {
+	var result []domain.UserProfileFact
+	for _, f := range m.facts {
+		if f.UserID == userID {
+			result = append(result, *f)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockFactRepo) GetByUserIDAndCategory(ctx context.Context, userID string, category domain.FactCategory) ([]domain.UserProfileFact, error) {
+	var result []domain.UserProfileFact
+	for _, f := range m.facts {
+		if f.UserID == userID && f.Category == category {
+			result = append(result, *f)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockFactRepo) List(ctx context.Context, f domain.UserProfileFactFilter) ([]domain.UserProfileFact, int, error) {
+	var result []domain.UserProfileFact
+	for _, fact := range m.facts {
+		if f.UserID != "" && fact.UserID != f.UserID {
+			continue
+		}
+		result = append(result, *fact)
+	}
+	return result, len(result), nil
+}
+
+func (m *mockFactRepo) Update(ctx context.Context, fact *domain.UserProfileFact) error {
+	if m.updateFunc != nil {
+		return m.updateFunc(ctx, fact)
+	}
+	m.facts[fact.FactID] = fact
+	return nil
+}
+
+func (m *mockFactRepo) Delete(ctx context.Context, factID string) error {
+	delete(m.facts, factID)
+	return nil
+}
+
+func (m *mockFactRepo) DeleteByUserID(ctx context.Context, userID string) error {
+	for id, f := range m.facts {
+		if f.UserID == userID {
+			delete(m.facts, id)
+		}
+	}
+	return nil
+}
+
+func (m *mockFactRepo) CountByUserID(ctx context.Context, userID string) (int, error) {
+	count := 0
+	for _, f := range m.facts {
+		if f.UserID == userID {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (m *mockFactRepo) DeleteOldestLowConfidence(ctx context.Context, userID string, count int) (int64, error) {
+	return 0, nil
+}
+
+func (m *mockFactRepo) TouchLastAccessed(ctx context.Context, factID string) error {
+	return nil
+}
+
+func (m *mockFactRepo) GetByKey(ctx context.Context, userID string, category domain.FactCategory, key string) (*domain.UserProfileFact, error) {
+	if m.getByKeyFunc != nil {
+		return m.getByKeyFunc(ctx, userID, category, key)
+	}
+	for _, f := range m.facts {
+		if f.UserID == userID && f.Category == category && f.Key == key {
+			return f, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+
+func (m *mockFactRepo) SearchByValue(ctx context.Context, userID string, value string, limit int) ([]domain.UserProfileFact, error) {
+	if m.searchFunc != nil {
+		return m.searchFunc(ctx, userID, value, limit)
+	}
+	return nil, nil
+}
+
+// mockLLMClient implements llm.Client for testing.
+type mockLLMClient struct {
+	response string
+	err      error
+}
+
+func (m *mockLLMClient) Complete(ctx context.Context, system, user string) (string, error) {
+	return m.response, m.err
+}
+
+func (m *mockLLMClient) CompleteJSON(ctx context.Context, system, user string) (string, error) {
+	return m.response, m.err
+}
+
+func TestDetectExplicitTriggers(t *testing.T) {
+	tests := []struct {
+		name            string
+		messages        []IngestMessage
+		expectedFacts   int
+		expectedKey     string
+		expectedValue   string
+		expectedCat     domain.FactCategory
+	}{
+		{
+			name: "Chinese explicit name trigger",
+			messages: []IngestMessage{
+				{Role: "user", Content: "记住我叫张三"},
+			},
+			expectedFacts: 1,
+			expectedKey:   "name",
+			expectedValue: "张三",
+			expectedCat:   domain.CategoryPersonal,
+		},
+		{
+			name: "Chinese 'my name is' pattern",
+			messages: []IngestMessage{
+				{Role: "user", Content: "我的名字是李四"},
+			},
+			expectedFacts: 1,
+			expectedKey:   "name",
+			expectedValue: "李四",
+			expectedCat:   domain.CategoryPersonal,
+		},
+		{
+			name: "English 'remember my name' trigger",
+			messages: []IngestMessage{
+				{Role: "user", Content: "Remember my name is John Smith"},
+			},
+			expectedFacts: 1,
+			expectedKey:   "name",
+			expectedValue: "John Smith",
+			expectedCat:   domain.CategoryPersonal,
+		},
+		{
+			name: "Chinese preference trigger",
+			messages: []IngestMessage{
+				{Role: "user", Content: "记住我喜欢吃披萨"},
+			},
+			expectedFacts: 1,
+			expectedKey:   "likes",
+			expectedValue: "吃披萨",
+			expectedCat:   domain.CategoryPreference,
+		},
+		{
+			name: "Chinese skill trigger",
+			messages: []IngestMessage{
+				{Role: "user", Content: "我会Python和Go"},
+			},
+			expectedFacts: 1,
+			expectedKey:   "skill",
+			expectedValue: "Python和Go",
+			expectedCat:   domain.CategorySkill,
+		},
+		{
+			name: "Chinese occupation trigger",
+			messages: []IngestMessage{
+				{Role: "user", Content: "我是后端工程师"},
+			},
+			expectedFacts: 1,
+			expectedKey:   "occupation",
+			expectedValue: "后端工程师",
+			expectedCat:   domain.CategoryPersonal,
+		},
+		{
+			name: "No explicit trigger - regular message",
+			messages: []IngestMessage{
+				{Role: "user", Content: "今天天气怎么样？"},
+			},
+			expectedFacts: 0,
+		},
+		{
+			name: "Assistant message ignored",
+			messages: []IngestMessage{
+				{Role: "assistant", Content: "记住你的名字是测试用户"},
+			},
+			expectedFacts: 0,
+		},
+		{
+			name: "Multiple user messages with triggers",
+			messages: []IngestMessage{
+				{Role: "user", Content: "记住我叫王五"},
+				{Role: "assistant", Content: "好的，我记住了。"},
+				{Role: "user", Content: "记住我喜欢编程"},
+			},
+			expectedFacts:   2,
+			expectedKey:     "name", // First fact
+			expectedValue:   "王五",
+			expectedCat:     domain.CategoryPersonal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newMockFactRepo()
+			userProf := NewUserProfileService(repo, 200)
+			extractor := NewExtractorService(repo, nil, userProf)
+
+			facts := extractor.detectExplicitTriggers(tt.messages)
+
+			if len(facts) != tt.expectedFacts {
+				t.Errorf("expected %d facts, got %d", tt.expectedFacts, len(facts))
+				return
+			}
+
+			if tt.expectedFacts > 0 {
+				if facts[0].Key != tt.expectedKey {
+					t.Errorf("expected key %q, got %q", tt.expectedKey, facts[0].Key)
+				}
+				if facts[0].Value != tt.expectedValue {
+					t.Errorf("expected value %q, got %q", tt.expectedValue, facts[0].Value)
+				}
+				if facts[0].Category != tt.expectedCat {
+					t.Errorf("expected category %q, got %q", tt.expectedCat, facts[0].Category)
+				}
+				if facts[0].Confidence != 1.0 {
+					t.Errorf("expected confidence 1.0 for explicit facts, got %f", facts[0].Confidence)
+				}
+				if facts[0].Source != domain.SourceExplicit {
+					t.Errorf("expected source explicit, got %s", facts[0].Source)
+				}
+			}
+		})
+	}
+}
+
+func TestIsSimilarValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        string
+		b        string
+		expected bool
+	}{
+		{
+			name:     "Exact match",
+			a:        "张三",
+			b:        "张三",
+			expected: true,
+		},
+		{
+			name:     "Case insensitive match",
+			a:        "Python",
+			b:        "python",
+			expected: true,
+		},
+		{
+			name:     "High overlap - containment match",
+			a:        "Python programming language",
+			b:        "Python programming",
+			expected: true, // "Python programming" is contained in longer string
+		},
+		{
+			name:     "Low overlap - not similar",
+			a:        "Python",
+			b:        "Python programming",
+			expected: false, // 6/19 = 0.31 ratio, below 0.9 threshold
+		},
+		{
+			name:     "Different values",
+			a:        "张三",
+			b:        "李四",
+			expected: false,
+		},
+		{
+			name:     "Completely different",
+			a:        "I like pizza",
+			b:        "I hate rain",
+			expected: false,
+		},
+		{
+			name:     "Whitespace difference",
+			a:        "Python ",
+			b:        " Python",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newMockFactRepo()
+			userProf := NewUserProfileService(repo, 200)
+			extractor := NewExtractorService(repo, nil, userProf)
+
+			result := extractor.isSimilarValue(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("isSimilarValue(%q, %q) = %v, expected %v", tt.a, tt.b, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMergeFacts(t *testing.T) {
+	explicit := []ExtractedFact{
+		{Category: domain.CategoryPersonal, Key: "name", Value: "张三", Confidence: 1.0, Source: domain.SourceExplicit},
+		{Category: domain.CategoryPreference, Key: "likes", Value: "编程", Confidence: 1.0, Source: domain.SourceExplicit},
+	}
+
+	implicit := []ExtractedFact{
+		{Category: domain.CategoryPersonal, Key: "name", Value: "李四", Confidence: 0.8, Source: domain.SourceInferred},
+		{Category: domain.CategorySkill, Key: "language", Value: "Python", Confidence: 0.9, Source: domain.SourceInferred},
+	}
+
+	repo := newMockFactRepo()
+	userProf := NewUserProfileService(repo, 200)
+	extractor := NewExtractorService(repo, nil, userProf)
+
+	merged := extractor.mergeFacts(explicit, implicit)
+
+	// Should have 3 facts: 2 explicit + 1 implicit (name from explicit takes precedence)
+	if len(merged) != 3 {
+		t.Errorf("expected 3 merged facts, got %d", len(merged))
+	}
+
+	// Check that explicit name fact is preserved
+	for _, f := range merged {
+		if f.Key == "name" {
+			if f.Value != "张三" {
+				t.Errorf("expected explicit name '张三' to take precedence, got %q", f.Value)
+			}
+			if f.Source != domain.SourceExplicit {
+				t.Errorf("expected explicit source, got %s", f.Source)
+			}
+		}
+	}
+}
+
+func TestDedupAndWrite_SkipExactMatch(t *testing.T) {
+	repo := newMockFactRepo()
+	// Pre-existing fact with same key
+	repo.facts["existing"] = &domain.UserProfileFact{
+		FactID:   "existing",
+		UserID:   "user1",
+		Category: domain.CategoryPersonal,
+		Key:      "name",
+		Value:    "张三",
+		Source:   domain.SourceExplicit,
+	}
+
+	userProf := NewUserProfileService(repo, 200)
+	extractor := NewExtractorService(repo, nil, userProf)
+
+	facts := []ExtractedFact{
+		{Category: domain.CategoryPersonal, Key: "name", Value: "张三", Confidence: 1.0, Source: domain.SourceExplicit},
+	}
+
+	result, err := extractor.dedupAndWrite(context.Background(), "user1", facts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.FactsSkipped != 1 {
+		t.Errorf("expected 1 skipped fact, got %d", result.FactsSkipped)
+	}
+	if result.FactsAdded != 0 {
+		t.Errorf("expected 0 added facts, got %d", result.FactsAdded)
+	}
+}
+
+func TestDedupAndWrite_UpdateExisting(t *testing.T) {
+	repo := newMockFactRepo()
+	// Pre-existing fact with same key but different value
+	repo.facts["existing"] = &domain.UserProfileFact{
+		FactID:   "existing",
+		UserID:   "user1",
+		Category: domain.CategoryPersonal,
+		Key:      "name",
+		Value:    "张三",
+		Source:   domain.SourceExplicit,
+	}
+
+	userProf := NewUserProfileService(repo, 200)
+	extractor := NewExtractorService(repo, nil, userProf)
+
+	facts := []ExtractedFact{
+		{Category: domain.CategoryPersonal, Key: "name", Value: "李四", Confidence: 1.0, Source: domain.SourceExplicit},
+	}
+
+	result, err := extractor.dedupAndWrite(context.Background(), "user1", facts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.FactsUpdated != 1 {
+		t.Errorf("expected 1 updated fact, got %d", result.FactsUpdated)
+	}
+	if result.FactsAdded != 0 {
+		t.Errorf("expected 0 added facts, got %d", result.FactsAdded)
+	}
+
+	// Verify the value was updated
+	updated := repo.facts["existing"]
+	if updated.Value != "李四" {
+		t.Errorf("expected updated value '李四', got %q", updated.Value)
+	}
+}
+
+func TestDedupAndWrite_CreateNew(t *testing.T) {
+	repo := newMockFactRepo()
+	userProf := NewUserProfileService(repo, 200)
+	extractor := NewExtractorService(repo, nil, userProf)
+
+	facts := []ExtractedFact{
+		{Category: domain.CategoryPersonal, Key: "name", Value: "王五", Confidence: 1.0, Source: domain.SourceExplicit},
+		{Category: domain.CategorySkill, Key: "language", Value: "Go", Confidence: 0.9, Source: domain.SourceInferred},
+	}
+
+	result, err := extractor.dedupAndWrite(context.Background(), "user1", facts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.FactsAdded != 2 {
+		t.Errorf("expected 2 added facts, got %d", result.FactsAdded)
+	}
+
+	// Verify facts were created
+	count, _ := repo.CountByUserID(context.Background(), "user1")
+	if count != 2 {
+		t.Errorf("expected 2 facts in repo, got %d", count)
+	}
+}
+
+func TestExtract_WithoutLLM(t *testing.T) {
+	repo := newMockFactRepo()
+	userProf := NewUserProfileService(repo, 200)
+	// No LLM client
+	extractor := NewExtractorService(repo, nil, userProf)
+
+	req := ExtractRequest{
+		Messages: []IngestMessage{
+			{Role: "user", Content: "记住我叫张三"},
+		},
+		UserID: "user1",
+	}
+
+	result, err := extractor.Extract(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Status != "complete" {
+		t.Errorf("expected status complete, got %s", result.Status)
+	}
+	if result.FactsAdded != 1 {
+		t.Errorf("expected 1 added fact, got %d", result.FactsAdded)
+	}
+
+	// Verify the fact was created with correct values
+	fact, err := repo.GetByKey(context.Background(), "user1", domain.CategoryPersonal, "name")
+	if err != nil {
+		t.Fatalf("failed to get created fact: %v", err)
+	}
+	if fact.Value != "张三" {
+		t.Errorf("expected value '张三', got %q", fact.Value)
+	}
+	if fact.Source != domain.SourceExplicit {
+		t.Errorf("expected source explicit, got %s", fact.Source)
+	}
+}
+
+func TestExtract_WithLLM(t *testing.T) {
+	repo := newMockFactRepo()
+	userProf := NewUserProfileService(repo, 200)
+
+	// Mock LLM response
+	llmClient := &mockLLMClient{
+		response: `{"facts": [{"category": "personal", "key": "occupation", "value": "后端工程师", "confidence": 1.0}, {"category": "skill", "key": "programming_language", "value": "Python 和 Go", "confidence": 1.0}]}`,
+	}
+
+	extractor := NewExtractorService(repo, llmClient, userProf)
+
+	req := ExtractRequest{
+		Messages: []IngestMessage{
+			{Role: "user", Content: "我是后端工程师，主要用 Python 和 Go。"},
+		},
+		UserID: "user1",
+	}
+
+	result, err := extractor.Extract(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Status != "complete" {
+		t.Errorf("expected status complete, got %s", result.Status)
+	}
+	if result.FactsAdded != 2 {
+		t.Errorf("expected 2 added facts, got %d", result.FactsAdded)
+	}
+}
+
+func TestExtract_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     ExtractRequest
+		errMsg  string
+	}{
+		{
+			name: "Missing user_id",
+			req: ExtractRequest{
+				Messages: []IngestMessage{{Role: "user", Content: "test"}},
+			},
+			errMsg: "user_id",
+		},
+		{
+			name: "Missing messages",
+			req: ExtractRequest{
+				UserID: "user1",
+			},
+			errMsg: "messages",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newMockFactRepo()
+			userProf := NewUserProfileService(repo, 200)
+			extractor := NewExtractorService(repo, nil, userProf)
+
+			_, err := extractor.Extract(context.Background(), tt.req)
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+
+			var valErr *domain.ValidationError
+			if errors.As(err, &valErr) {
+				if valErr.Field != tt.errMsg {
+					t.Errorf("expected field %q, got %q", tt.errMsg, valErr.Field)
+				}
+			} else {
+				t.Errorf("expected ValidationError, got %T", err)
+			}
+		})
+	}
+}
+
+func TestNormalizeFactKey(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Name", "name"},
+		{"User Name", "user_name"},
+		{"user-name", "user_name"},
+		{"User  Name", "user_name"},
+		{"  name  ", "name"},
+		{"Programming Language", "programming_language"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := NormalizeFactKey(tt.input)
+			if result != tt.expected {
+				t.Errorf("NormalizeFactKey(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractFromContent(t *testing.T) {
+	repo := newMockFactRepo()
+	userProf := NewUserProfileService(repo, 200)
+	extractor := NewExtractorService(repo, nil, userProf)
+
+	result, err := extractor.ExtractFromContent(context.Background(), "user1", "记住我叫测试用户")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.FactsAdded != 1 {
+		t.Errorf("expected 1 added fact, got %d", result.FactsAdded)
+	}
+
+	fact, err := repo.GetByKey(context.Background(), "user1", domain.CategoryPersonal, "name")
+	if err != nil {
+		t.Fatalf("failed to get created fact: %v", err)
+	}
+	if fact.Value != "测试用户" {
+		t.Errorf("expected value '测试用户', got %q", fact.Value)
+	}
+}
+
+func TestExtractFromContent_EmptyContent(t *testing.T) {
+	repo := newMockFactRepo()
+	userProf := NewUserProfileService(repo, 200)
+	extractor := NewExtractorService(repo, nil, userProf)
+
+	_, err := extractor.ExtractFromContent(context.Background(), "user1", "")
+	if err == nil {
+		t.Fatal("expected validation error for empty content")
+	}
+
+	var valErr *domain.ValidationError
+	if !errors.As(err, &valErr) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+// Test StripMarkdownFences from llm package
+func TestStripMarkdownFences(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "```json\n{\"facts\": []}\n```",
+			expected: "{\"facts\": []}",
+		},
+		{
+			input:    "```\n{\"facts\": []}\n```",
+			expected: "{\"facts\": []}",
+		},
+		{
+			input:    "{\"facts\": []}",
+			expected: "{\"facts\": []}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := llm.StripMarkdownFences(tt.input)
+			if result != tt.expected {
+				t.Errorf("StripMarkdownFences(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/server/internal/service/user_profile_test.go
+++ b/server/internal/service/user_profile_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/devioslang/memorix/server/internal/domain"
@@ -139,6 +140,28 @@ func (m *mockUserProfileFactRepo) DeleteOldestLowConfidence(ctx context.Context,
 
 func (m *mockUserProfileFactRepo) TouchLastAccessed(ctx context.Context, factID string) error {
 	return nil
+}
+
+func (m *mockUserProfileFactRepo) GetByKey(ctx context.Context, userID string, category domain.FactCategory, key string) (*domain.UserProfileFact, error) {
+	for _, f := range m.facts {
+		if f.UserID == userID && f.Category == category && f.Key == key {
+			return f, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+
+func (m *mockUserProfileFactRepo) SearchByValue(ctx context.Context, userID string, value string, limit int) ([]domain.UserProfileFact, error) {
+	var result []domain.UserProfileFact
+	for _, f := range m.facts {
+		if f.UserID == userID && strings.Contains(strings.ToLower(f.Value), strings.ToLower(value)) {
+			result = append(result, *f)
+			if len(result) >= limit {
+				break
+			}
+		}
+	}
+	return result, nil
 }
 
 func TestValidateCreateFactInput(t *testing.T) {


### PR DESCRIPTION
Closes #5

Implements automatic fact extraction from conversations.

Key changes:
- Extraction prompt design for structured facts
- Explicit trigger detection (记住xxx, 我的xxx是xxx)
- Implicit extraction via LLM after each conversation
- Integration with User Profile Store CRUD API
- Deduplication logic (exact key match or 0.9 text similarity)