### PR TITLE
feat: add Conversation Summarizer for recent conversation summary layer

### DIFF
--- a/server/internal/domain/conversation_summary.go
+++ b/server/internal/domain/conversation_summary.go
@@ -1,0 +1,63 @@
+package domain
+
+import (
+	"time"
+)
+
+// ConversationSummary represents a summary of a completed conversation session.
+// Based on ChatGPT's fourth-layer "recent conversation summary" design from reverse engineering analysis.
+// Key advantages: zero retrieval latency (pre-computed), provides context for ongoing conversations.
+type ConversationSummary struct {
+	SummaryID string `json:"summary_id"`
+	UserID    string `json:"user_id"`
+	SessionID string `json:"session_id"`
+
+	// LLM-generated content
+	Title      string   `json:"title"`        // Conversation title (LLM generated)
+	Summary    string   `json:"summary"`      // Summary within 200 Chinese characters
+	KeyTopics  []string `json:"key_topics"`   // Key topic tags
+	UserIntent string   `json:"user_intent"`  // Core user intent
+
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// ConversationSummaryFilter encapsulates query parameters for summary queries.
+type ConversationSummaryFilter struct {
+	UserID    string
+	SessionID string
+	KeyTopic  string // Filter by topic (partial match)
+	Limit     int
+	Offset    int
+}
+
+// Default capacity limits for the sliding window
+const (
+	DefaultMaxSummariesPerUser = 20 // Maximum summaries to keep per user
+	MinSummariesPerUser        = 15 // Minimum before cleanup triggers
+	MaxSummaryLength           = 200 // Maximum characters for summary field
+	MaxTitleLength             = 100 // Maximum characters for title
+	MaxTopicsCount             = 5   // Maximum number of key topics
+	MaxUserIntentLength        = 100 // Maximum characters for user intent
+)
+
+// SummaryGenerationRequest contains the input for generating a conversation summary.
+type SummaryGenerationRequest struct {
+	UserID    string          `json:"user_id"`
+	SessionID string          `json:"session_id"`
+	Messages  []SummaryMessage `json:"messages"`
+}
+
+// SummaryMessage represents a single message in the conversation.
+type SummaryMessage struct {
+	Role      string `json:"role"`       // "user" or "assistant"
+	Content   string `json:"content"`
+	Timestamp string `json:"timestamp,omitempty"`
+}
+
+// SummaryGenerationResult contains the LLM-generated summary data.
+type SummaryGenerationResult struct {
+	Title      string   `json:"title"`
+	Summary    string   `json:"summary"`
+	KeyTopics  []string `json:"key_topics"`
+	UserIntent string   `json:"user_intent"`
+}

--- a/server/internal/handler/conversation_summary.go
+++ b/server/internal/handler/conversation_summary.go
@@ -1,0 +1,130 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/devioslang/memorix/server/internal/domain"
+	"github.com/devioslang/memorix/server/internal/service"
+	"github.com/go-chi/chi/v5"
+)
+
+// summarizeRequest is the request body for generating a conversation summary.
+type summarizeRequest struct {
+	UserID    string                   `json:"user_id"`
+	SessionID string                   `json:"session_id,omitempty"`
+	Messages  []domain.SummaryMessage  `json:"messages"`
+}
+
+// summaryListResponse is the response for listing summaries.
+type summaryListResponse struct {
+	Summaries []domain.ConversationSummary `json:"summaries"`
+	Total     int                          `json:"total"`
+	Limit     int                          `json:"limit"`
+	Offset    int                          `json:"offset"`
+}
+
+// summarize handles POST /summaries
+// It generates a summary for a completed conversation.
+func (s *Server) summarize(w http.ResponseWriter, r *http.Request) {
+	var req summarizeRequest
+	if err := decode(r, &req); err != nil {
+		s.handleError(w, err)
+		return
+	}
+
+	auth := authInfo(r)
+	svc := s.resolveSummarizerServices(auth)
+
+	summarizeReq := service.SummarizeRequest{
+		UserID:    req.UserID,
+		SessionID: req.SessionID,
+		Messages:  req.Messages,
+	}
+
+	result, err := svc.Summarize(r.Context(), summarizeReq)
+	if err != nil {
+		s.handleError(w, err)
+		return
+	}
+
+	status := http.StatusOK
+	if result.Status == "failed" {
+		status = http.StatusInternalServerError
+	}
+
+	respond(w, status, result)
+}
+
+// listSummaries handles GET /summaries
+// It lists summaries for a user.
+func (s *Server) listSummaries(w http.ResponseWriter, r *http.Request) {
+	auth := authInfo(r)
+	svc := s.resolveSummarizerServices(auth)
+	q := r.URL.Query()
+
+	limit, _ := strconv.Atoi(q.Get("limit"))
+	offset, _ := strconv.Atoi(q.Get("offset"))
+	if limit <= 0 || limit > 50 {
+		limit = 20
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	filter := domain.ConversationSummaryFilter{
+		UserID:    q.Get("user_id"),
+		SessionID: q.Get("session_id"),
+		KeyTopic:  q.Get("topic"),
+		Limit:     limit,
+		Offset:    offset,
+	}
+
+	summaries, total, err := svc.ListSummaries(r.Context(), filter)
+	if err != nil {
+		s.handleError(w, err)
+		return
+	}
+
+	if summaries == nil {
+		summaries = []domain.ConversationSummary{}
+	}
+
+	respond(w, http.StatusOK, summaryListResponse{
+		Summaries: summaries,
+		Total:     total,
+		Limit:     limit,
+		Offset:    offset,
+	})
+}
+
+// getSummary handles GET /summaries/{id}
+// It retrieves a single summary by ID.
+func (s *Server) getSummary(w http.ResponseWriter, r *http.Request) {
+	auth := authInfo(r)
+	svc := s.resolveSummarizerServices(auth)
+	id := chi.URLParam(r, "id")
+
+	summary, err := svc.GetSummary(r.Context(), id)
+	if err != nil {
+		s.handleError(w, err)
+		return
+	}
+
+	respond(w, http.StatusOK, summary)
+}
+
+// deleteSummary handles DELETE /summaries/{id}
+// It deletes a summary by ID.
+func (s *Server) deleteSummary(w http.ResponseWriter, r *http.Request) {
+	auth := authInfo(r)
+	svc := s.resolveSummarizerServices(auth)
+	id := chi.URLParam(r, "id")
+
+	if err := svc.DeleteSummary(r.Context(), id); err != nil {
+		s.handleError(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -44,6 +44,9 @@ type Server struct {
 
 	// User profile configuration
 	maxFactsPerUser int
+
+	// Conversation summary configuration
+	maxSummariesPerUser int
 }
 
 // NewServer creates a new HTTP handler server.
@@ -113,6 +116,7 @@ func NewServer(
 		contextWindowConfig:  contextConfig,
 		contextBuilderConfig: builderConfig,
 		maxFactsPerUser:      200, // Default capacity per user
+		maxSummariesPerUser:  20,  // Default sliding window size per user
 	}
 }
 
@@ -124,6 +128,7 @@ type resolvedSvc struct {
 	userProfile *service.UserProfileService
 	extractor   *service.ExtractorService
 	reconciler  *service.ReconcilerService
+	summarizer  *service.ConversationSummarizerService
 }
 
 type tenantSvcKey string
@@ -138,14 +143,17 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 		memRepo := tidb.NewMemoryRepo(auth.TenantDB, s.autoModel, s.ftsEnabled)
 		factRepo := tidb.NewUserProfileFactRepo(auth.TenantDB)
 		auditRepo := tidb.NewReconcileAuditRepo(auth.TenantDB)
+		summaryRepo := tidb.NewConversationSummaryRepo(auth.TenantDB)
 		userProf := service.NewUserProfileService(factRepo, s.maxFactsPerUser)
 		reconciler := service.NewReconcilerService(factRepo, auditRepo, s.llmClient)
+		summarizer := service.NewConversationSummarizerService(summaryRepo, s.llmClient, s.maxSummariesPerUser)
 		svc := resolvedSvc{
 			memory:      service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
 			ingest:      service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
 			userProfile: userProf,
 			extractor:   service.NewExtractorService(factRepo, s.llmClient, userProf),
 			reconciler:  reconciler,
+			summarizer:  summarizer,
 		}
 		s.svcCache.Store(key, svc)
 		return svc
@@ -157,14 +165,17 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 	memRepo := tidb.NewMemoryRepo(auth.TenantDB, s.autoModel, s.ftsEnabled)
 	factRepo := tidb.NewUserProfileFactRepo(auth.TenantDB)
 	auditRepo := tidb.NewReconcileAuditRepo(auth.TenantDB)
+	summaryRepo := tidb.NewConversationSummaryRepo(auth.TenantDB)
 	userProf := service.NewUserProfileService(factRepo, s.maxFactsPerUser)
 	reconciler := service.NewReconcilerService(factRepo, auditRepo, s.llmClient)
+	summarizer := service.NewConversationSummarizerService(summaryRepo, s.llmClient, s.maxSummariesPerUser)
 	svc := resolvedSvc{
 		memory:      service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
 		ingest:      service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
 		userProfile: userProf,
 		extractor:   service.NewExtractorService(factRepo, s.llmClient, userProf),
 		reconciler:  reconciler,
+		summarizer:  summarizer,
 	}
 	s.svcCache.Store(key, svc)
 	return svc
@@ -183,6 +194,11 @@ func (s *Server) resolveExtractorServices(auth *domain.AuthInfo) *service.Extrac
 // resolveReconcilerServices returns the ReconcilerService for a request.
 func (s *Server) resolveReconcilerServices(auth *domain.AuthInfo) *service.ReconcilerService {
 	return s.resolveServices(auth).reconciler
+}
+
+// resolveSummarizerServices returns the ConversationSummarizerService for a request.
+func (s *Server) resolveSummarizerServices(auth *domain.AuthInfo) *service.ConversationSummarizerService {
+	return s.resolveServices(auth).summarizer
 }
 
 // Router builds the chi router with all routes and middleware.
@@ -239,6 +255,12 @@ func (s *Server) Router(tenantMW, rateLimitMW func(http.Handler) http.Handler) h
 		r.Post("/user-profile/reconcile", s.batchReconcile)
 		r.Get("/user-profile/reconcile/audit", s.listAuditLogs)
 		r.Get("/user-profile/reconcile/audit/{fact_id}", s.listFactAuditLogs)
+
+		// Conversation Summaries (recent conversation summary layer).
+		r.Post("/summaries", s.summarize)
+		r.Get("/summaries", s.listSummaries)
+		r.Get("/summaries/{id}", s.getSummary)
+		r.Delete("/summaries/{id}", s.deleteSummary)
 
 	})
 

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -119,3 +119,33 @@ type ReconcileAuditRepo interface {
 	// DeleteByUserID deletes all audit logs for a user (used when user is deleted).
 	DeleteByUserID(ctx context.Context, userID string) error
 }
+
+// ConversationSummaryRepo manages conversation summaries.
+// This implements the "fourth layer" of ChatGPT's memory system - recent conversation summaries.
+// Key feature: sliding window of 15-20 summaries per user with zero retrieval latency.
+type ConversationSummaryRepo interface {
+	// Create stores a new conversation summary.
+	Create(ctx context.Context, summary *domain.ConversationSummary) error
+
+	// GetByID retrieves a summary by its ID.
+	GetByID(ctx context.Context, summaryID string) (*domain.ConversationSummary, error)
+
+	// GetByUserID retrieves all summaries for a user, ordered by created_at desc.
+	GetByUserID(ctx context.Context, userID string, limit int) ([]domain.ConversationSummary, error)
+
+	// GetBySessionID retrieves a summary by session ID.
+	GetBySessionID(ctx context.Context, sessionID string) (*domain.ConversationSummary, error)
+
+	// List retrieves summaries with filtering and pagination.
+	List(ctx context.Context, f domain.ConversationSummaryFilter) (summaries []domain.ConversationSummary, total int, err error)
+
+	// Delete removes a summary by ID.
+	Delete(ctx context.Context, summaryID string) error
+
+	// DeleteOldest removes the oldest summaries for a user to maintain the sliding window.
+	// Returns the number of summaries deleted.
+	DeleteOldest(ctx context.Context, userID string, count int) (int64, error)
+
+	// CountByUserID returns the total number of summaries for a user.
+	CountByUserID(ctx context.Context, userID string) (int, error)
+}

--- a/server/internal/repository/tidb/conversation_summary.go
+++ b/server/internal/repository/tidb/conversation_summary.go
@@ -1,0 +1,274 @@
+package tidb
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/devioslang/memorix/server/internal/domain"
+)
+
+// ConversationSummaryRepo implements repository.ConversationSummaryRepo using TiDB.
+type ConversationSummaryRepo struct {
+	db *sql.DB
+}
+
+// NewConversationSummaryRepo creates a new ConversationSummaryRepo.
+func NewConversationSummaryRepo(db *sql.DB) *ConversationSummaryRepo {
+	return &ConversationSummaryRepo{db: db}
+}
+
+const summaryAllColumns = `summary_id, user_id, session_id, title, summary, key_topics, user_intent, created_at`
+
+// Create inserts a new conversation summary.
+func (r *ConversationSummaryRepo) Create(ctx context.Context, summary *domain.ConversationSummary) error {
+	var topicsJSON []byte
+	var err error
+	if len(summary.KeyTopics) > 0 {
+		topicsJSON, err = json.Marshal(summary.KeyTopics)
+		if err != nil {
+			return fmt.Errorf("marshal key_topics: %w", err)
+		}
+	} else {
+		topicsJSON = []byte("[]")
+	}
+
+	_, err = r.db.ExecContext(ctx,
+		`INSERT INTO conversation_summaries (summary_id, user_id, session_id, title, summary, key_topics, user_intent, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, NOW())`,
+		summary.SummaryID, summary.UserID, summary.SessionID, summary.Title, summary.Summary, topicsJSON, summary.UserIntent,
+	)
+	if err != nil {
+		return fmt.Errorf("create conversation summary: %w", err)
+	}
+	return nil
+}
+
+// GetByID retrieves a summary by its ID.
+func (r *ConversationSummaryRepo) GetByID(ctx context.Context, summaryID string) (*domain.ConversationSummary, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT `+summaryAllColumns+` FROM conversation_summaries WHERE summary_id = ?`, summaryID,
+	)
+	return scanConversationSummary(row)
+}
+
+// GetByUserID retrieves all summaries for a user, ordered by created_at desc.
+func (r *ConversationSummaryRepo) GetByUserID(ctx context.Context, userID string, limit int) ([]domain.ConversationSummary, error) {
+	if limit <= 0 {
+		limit = domain.DefaultMaxSummariesPerUser
+	}
+
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT `+summaryAllColumns+` FROM conversation_summaries WHERE user_id = ? ORDER BY created_at DESC LIMIT ?`,
+		userID, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get user summaries: %w", err)
+	}
+	defer rows.Close()
+
+	return scanConversationSummaries(rows)
+}
+
+// GetBySessionID retrieves a summary by session ID.
+func (r *ConversationSummaryRepo) GetBySessionID(ctx context.Context, sessionID string) (*domain.ConversationSummary, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT `+summaryAllColumns+` FROM conversation_summaries WHERE session_id = ?`,
+		sessionID,
+	)
+	return scanConversationSummary(row)
+}
+
+// List retrieves summaries with filtering and pagination.
+func (r *ConversationSummaryRepo) List(ctx context.Context, f domain.ConversationSummaryFilter) ([]domain.ConversationSummary, int, error) {
+	conds, args := r.buildFilterConds(f)
+	where := "1=1"
+	if len(conds) > 0 {
+		where = ""
+		for i, cond := range conds {
+			if i > 0 {
+				where += " AND "
+			}
+			where += cond
+		}
+	}
+
+	// Count total matches.
+	var total int
+	countQuery := "SELECT COUNT(*) FROM conversation_summaries WHERE " + where
+	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count summaries: %w", err)
+	}
+
+	// Fetch page.
+	limit := f.Limit
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	offset := f.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	dataQuery := "SELECT " + summaryAllColumns + " FROM conversation_summaries WHERE " +
+		where + " ORDER BY created_at DESC LIMIT ? OFFSET ?"
+	dataArgs := make([]any, len(args), len(args)+2)
+	copy(dataArgs, args)
+	dataArgs = append(dataArgs, limit, offset)
+
+	rows, err := r.db.QueryContext(ctx, dataQuery, dataArgs...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list summaries: %w", err)
+	}
+	defer rows.Close()
+
+	summaries, err := scanConversationSummaries(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+	return summaries, total, nil
+}
+
+// Delete removes a summary by ID.
+func (r *ConversationSummaryRepo) Delete(ctx context.Context, summaryID string) error {
+	result, err := r.db.ExecContext(ctx,
+		`DELETE FROM conversation_summaries WHERE summary_id = ?`,
+		summaryID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete conversation summary: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
+// DeleteOldest removes the oldest summaries for a user to maintain the sliding window.
+// It deletes the oldest summaries first (by created_at).
+// Returns the number of summaries deleted.
+func (r *ConversationSummaryRepo) DeleteOldest(ctx context.Context, userID string, count int) (int64, error) {
+	// Find the IDs of summaries to delete (oldest first)
+	query := `
+		SELECT summary_id FROM conversation_summaries
+		WHERE user_id = ?
+		ORDER BY created_at ASC
+		LIMIT ?
+	`
+	rows, err := r.db.QueryContext(ctx, query, userID, count)
+	if err != nil {
+		return 0, fmt.Errorf("find oldest summaries: %w", err)
+	}
+	defer rows.Close()
+
+	var summaryIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return 0, fmt.Errorf("scan summary id: %w", err)
+		}
+		summaryIDs = append(summaryIDs, id)
+	}
+
+	if len(summaryIDs) == 0 {
+		return 0, nil
+	}
+
+	// Delete by IDs
+	result, err := r.db.ExecContext(ctx,
+		`DELETE FROM conversation_summaries WHERE summary_id IN (`+placeholders(len(summaryIDs))+`)`,
+		stringsToArgs(summaryIDs)...,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("delete oldest summaries: %w", err)
+	}
+	return result.RowsAffected()
+}
+
+// CountByUserID returns the total number of summaries for a user.
+func (r *ConversationSummaryRepo) CountByUserID(ctx context.Context, userID string) (int, error) {
+	var count int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM conversation_summaries WHERE user_id = ?`,
+		userID,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count user summaries: %w", err)
+	}
+	return count, nil
+}
+
+func (r *ConversationSummaryRepo) buildFilterConds(f domain.ConversationSummaryFilter) ([]string, []any) {
+	conds := []string{}
+	args := []any{}
+
+	if f.UserID != "" {
+		conds = append(conds, "user_id = ?")
+		args = append(args, f.UserID)
+	}
+	if f.SessionID != "" {
+		conds = append(conds, "session_id = ?")
+		args = append(args, f.SessionID)
+	}
+	if f.KeyTopic != "" {
+		conds = append(conds, "JSON_CONTAINS(key_topics, ?)")
+		args = append(args, fmt.Sprintf(`"%s"`, f.KeyTopic))
+	}
+
+	return conds, args
+}
+
+func scanConversationSummary(row *sql.Row) (*domain.ConversationSummary, error) {
+	var s domain.ConversationSummary
+	var topicsJSON []byte
+	var sessionID sql.NullString
+
+	err := row.Scan(&s.SummaryID, &s.UserID, &sessionID, &s.Title, &s.Summary, &topicsJSON, &s.UserIntent, &s.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, domain.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan conversation summary: %w", err)
+	}
+
+	s.SessionID = sessionID.String
+
+	// Parse key_topics JSON
+	if len(topicsJSON) > 0 {
+		if err := json.Unmarshal(topicsJSON, &s.KeyTopics); err != nil {
+			// Log warning but continue with empty topics
+			s.KeyTopics = []string{}
+		}
+	}
+
+	return &s, nil
+}
+
+func scanConversationSummaries(rows *sql.Rows) ([]domain.ConversationSummary, error) {
+	var summaries []domain.ConversationSummary
+	for rows.Next() {
+		var s domain.ConversationSummary
+		var topicsJSON []byte
+		var sessionID sql.NullString
+
+		err := rows.Scan(&s.SummaryID, &s.UserID, &sessionID, &s.Title, &s.Summary, &topicsJSON, &s.UserIntent, &s.CreatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("scan conversation summary row: %w", err)
+		}
+
+		s.SessionID = sessionID.String
+
+		// Parse key_topics JSON
+		if len(topicsJSON) > 0 {
+			if err := json.Unmarshal(topicsJSON, &s.KeyTopics); err != nil {
+				// Log warning but continue with empty topics
+				s.KeyTopics = []string{}
+			}
+		}
+
+		summaries = append(summaries, s)
+	}
+	return summaries, rows.Err()
+}

--- a/server/internal/service/conversation_summarizer.go
+++ b/server/internal/service/conversation_summarizer.go
@@ -1,0 +1,344 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+
+	"github.com/devioslang/memorix/server/internal/domain"
+	"github.com/devioslang/memorix/server/internal/llm"
+	"github.com/devioslang/memorix/server/internal/repository"
+)
+
+// ConversationSummarizerService generates and manages conversation summaries.
+// Implements the "fourth layer" of ChatGPT's memory system - recent conversation summaries.
+// Key features:
+// - Pre-computed summaries for zero retrieval latency
+// - Sliding window of 15-20 summaries per user
+// - LLM-generated title, summary, key topics, and user intent
+type ConversationSummarizerService struct {
+	summaries    repository.ConversationSummaryRepo
+	llm          LLMClient
+	maxSummaries int
+}
+
+// NewConversationSummarizerService creates a new ConversationSummarizerService.
+func NewConversationSummarizerService(
+	summaries repository.ConversationSummaryRepo,
+	llmClient LLMClient,
+	maxSummaries int,
+) *ConversationSummarizerService {
+	if maxSummaries <= 0 {
+		maxSummaries = domain.DefaultMaxSummariesPerUser
+	}
+	return &ConversationSummarizerService{
+		summaries:    summaries,
+		llm:          llmClient,
+		maxSummaries: maxSummaries,
+	}
+}
+
+// SummarizeRequest contains the input for generating a conversation summary.
+type SummarizeRequest struct {
+	UserID    string                   `json:"user_id"`
+	SessionID string                   `json:"session_id,omitempty"`
+	Messages  []domain.SummaryMessage `json:"messages"`
+}
+
+// SummarizeResult contains the result of the summarization process.
+type SummarizeResult struct {
+	Status     string                        `json:"status"` // complete | failed
+	SummaryID  string                        `json:"summary_id,omitempty"`
+	Summary    *domain.ConversationSummary  `json:"summary,omitempty"`
+	Error      string                        `json:"error,omitempty"`
+	Skipped    bool                          `json:"skipped,omitempty"` // true if summary already exists
+}
+
+// Summarize generates a summary for a completed conversation.
+// It:
+// 1. Checks if a summary already exists for the session (skips if so)
+// 2. Calls LLM to generate structured summary
+// 3. Enforces sliding window by deleting oldest summaries if needed
+// 4. Stores the new summary
+func (s *ConversationSummarizerService) Summarize(ctx context.Context, req SummarizeRequest) (*SummarizeResult, error) {
+	slog.Info("summarizer started", "user_id", req.UserID, "session_id", req.SessionID, "messages", len(req.Messages))
+
+	// Validate input
+	if req.UserID == "" {
+		return nil, &domain.ValidationError{Field: "user_id", Message: "required"}
+	}
+	if len(req.Messages) == 0 {
+		return nil, &domain.ValidationError{Field: "messages", Message: "required"}
+	}
+
+	// Check if summary already exists for this session
+	if req.SessionID != "" {
+		existing, err := s.summaries.GetBySessionID(ctx, req.SessionID)
+		if err != nil && err != domain.ErrNotFound {
+			slog.Warn("failed to check existing summary", "err", err, "session_id", req.SessionID)
+			// Continue anyway
+		}
+		if existing != nil {
+			slog.Info("summary already exists for session", "session_id", req.SessionID, "summary_id", existing.SummaryID)
+			return &SummarizeResult{
+				Status:    "complete",
+				SummaryID: existing.SummaryID,
+				Summary:   existing,
+				Skipped:   true,
+			}, nil
+		}
+	}
+
+	// If no LLM client, we cannot generate summaries
+	if s.llm == nil {
+		return &SummarizeResult{
+			Status: "failed",
+			Error:  "LLM client not configured",
+		}, nil
+	}
+
+	// Format conversation for LLM
+	conversation := formatConversationForSummary(req.Messages)
+	if conversation == "" {
+		return &SummarizeResult{
+			Status: "complete", // Empty conversation, nothing to summarize
+		}, nil
+	}
+
+	// Truncate if too long (avoid LLM token limits)
+	const maxConversationRunes = 50000
+	if utf8.RuneCountInString(conversation) > maxConversationRunes {
+		runes := []rune(conversation)
+		conversation = string(runes[:maxConversationRunes]) + "\n...[truncated]"
+	}
+
+	// Call LLM to generate summary
+	summaryData, err := s.generateSummary(ctx, conversation)
+	if err != nil {
+		slog.Error("failed to generate summary", "err", err, "user_id", req.UserID)
+		return &SummarizeResult{
+			Status: "failed",
+			Error:  err.Error(),
+		}, nil
+	}
+
+	// Check capacity and enforce sliding window
+	count, err := s.summaries.CountByUserID(ctx, req.UserID)
+	if err != nil {
+		slog.Warn("failed to count summaries", "err", err, "user_id", req.UserID)
+		count = 0 // Continue anyway
+	}
+
+	// If at capacity, delete oldest to maintain sliding window
+	if count >= s.maxSummaries {
+		toDelete := count - s.maxSummaries + 1
+		if toDelete > 0 {
+			deleted, err := s.summaries.DeleteOldest(ctx, req.UserID, toDelete)
+			if err != nil {
+				slog.Warn("failed to delete oldest summaries", "err", err, "user_id", req.UserID, "count", toDelete)
+			} else {
+				slog.Info("deleted oldest summaries for sliding window", "user_id", req.UserID, "deleted", deleted)
+			}
+		}
+	}
+
+	// Create and store the summary
+	summary := &domain.ConversationSummary{
+		SummaryID:  uuid.New().String(),
+		UserID:     req.UserID,
+		SessionID:  req.SessionID,
+		Title:      summaryData.Title,
+		Summary:    summaryData.Summary,
+		KeyTopics:  summaryData.KeyTopics,
+		UserIntent: summaryData.UserIntent,
+		CreatedAt:  time.Now(),
+	}
+
+	if err := s.summaries.Create(ctx, summary); err != nil {
+		return nil, fmt.Errorf("store summary: %w", err)
+	}
+
+	slog.Info("summary created", "summary_id", summary.SummaryID, "user_id", req.UserID, "title", summary.Title)
+
+	return &SummarizeResult{
+		Status:    "complete",
+		SummaryID: summary.SummaryID,
+		Summary:   summary,
+	}, nil
+}
+
+// generateSummary calls the LLM to generate a structured conversation summary.
+func (s *ConversationSummarizerService) generateSummary(ctx context.Context, conversation string) (*domain.SummaryGenerationResult, error) {
+	currentDate := time.Now().Format("2006-01-02")
+
+	systemPrompt := `You are a conversation summarization engine. Your task is to analyze a conversation and generate a structured summary with title, summary text, key topics, and user intent.
+
+## Requirements
+
+1. **title**: A brief, descriptive title for the conversation (max 100 characters)
+   - Should capture the main topic or purpose
+   - Use the user's primary language
+   - Example: "Go concurrency patterns discussion" or "Python 数据处理方案"
+
+2. **summary**: A concise summary of the conversation (max 200 Chinese characters or ~100 English words)
+   - Focus on what was discussed, not the mechanics of the conversation
+   - Include key decisions, solutions, or outcomes
+   - Preserve the user's language
+   - Omit greetings, filler, and meta-commentary
+
+3. **key_topics**: An array of 2-5 topic tags that categorize this conversation
+   - Use lowercase English snake_case
+   - Examples: ["go_programming", "concurrency", "best_practices"]
+   - Keep topics general enough for cross-conversation relevance
+
+4. **user_intent**: What the user wanted to achieve from this conversation (max 100 characters)
+   - Focus on the user's goal, not what happened
+   - Examples: "Learn Go concurrency patterns" or "Fix Python data pipeline bug"
+
+## Examples
+
+Input:
+User: Can you help me understand Go channels?
+Assistant: Of course! Go channels are a powerful concurrency primitive. They allow goroutines to communicate and synchronize...
+User: What's the difference between buffered and unbuffered channels?
+Assistant: Unbuffered channels block until both sender and receiver are ready. Buffered channels have a capacity...
+User: When should I use which one?
+Assistant: Use unbuffered for synchronization, buffered when you need to decouple sender/receiver rates...
+
+Output:
+{
+  "title": "Go channels deep dive",
+  "summary": "Explored Go channels including buffered vs unbuffered differences, use cases, and synchronization patterns. Covered when to use each type.",
+  "key_topics": ["go", "concurrency", "channels", "goroutines"],
+  "user_intent": "Understand Go channel types and usage"
+}
+
+Input:
+User: 我的 Python 脚本处理大数据集时内存不足，有什么解决方案？
+Assistant: 有几个方案：1. 使用生成器逐行处理；2. 使用 pandas 的 chunk 读取；3. 使用 Dask 进行分布式处理...
+User: 能详细说说 pandas chunk 怎么用吗？
+Assistant: 可以使用 pd.read_csv 的 chunksize 参数...
+
+Output:
+{
+  "title": "Python 大数据处理内存优化",
+  "summary": "讨论了处理大数据集时的内存问题解决方案，重点介绍了 pandas 的分块读取方法。用户需要处理大型 CSV 文件。",
+  "key_topics": ["python", "pandas", "memory_optimization", "big_data"],
+  "user_intent": "解决大数据处理的内存溢出问题"
+}
+
+## Output Format
+
+Return ONLY valid JSON. No markdown fences, no explanation.
+
+{
+  "title": "...",
+  "summary": "...",
+  "key_topics": ["...", "..."],
+  "user_intent": "..."
+}`
+
+	userPrompt := fmt.Sprintf("Generate a structured summary for this conversation. Today's date is %s.\n\n%s", currentDate, conversation)
+
+	raw, err := s.llm.CompleteJSON(ctx, systemPrompt, userPrompt)
+	if err != nil {
+		return nil, fmt.Errorf("summary LLM call: %w", err)
+	}
+
+	parsed, err := llm.ParseJSON[domain.SummaryGenerationResult](raw)
+	if err != nil {
+		// Retry once without JSON format requirement
+		raw2, retryErr := s.llm.CompleteJSON(ctx, systemPrompt,
+			"Your previous response was not valid JSON. Return ONLY the JSON object.\n\n"+userPrompt)
+		if retryErr != nil {
+			return nil, fmt.Errorf("summary retry: %w", retryErr)
+		}
+		parsed, err = llm.ParseJSON[domain.SummaryGenerationResult](raw2)
+		if err != nil {
+			return nil, fmt.Errorf("summary parse after retry: %w", err)
+		}
+	}
+
+	// Validate and truncate fields
+	if parsed.Title == "" {
+		parsed.Title = "Untitled conversation"
+	}
+	if utf8.RuneCountInString(parsed.Title) > domain.MaxTitleLength {
+		parsed.Title = string([]rune(parsed.Title)[:domain.MaxTitleLength])
+	}
+	if utf8.RuneCountInString(parsed.Summary) > domain.MaxSummaryLength {
+		parsed.Summary = string([]rune(parsed.Summary)[:domain.MaxSummaryLength])
+	}
+	if utf8.RuneCountInString(parsed.UserIntent) > domain.MaxUserIntentLength {
+		parsed.UserIntent = string([]rune(parsed.UserIntent)[:domain.MaxUserIntentLength])
+	}
+	if len(parsed.KeyTopics) > domain.MaxTopicsCount {
+		parsed.KeyTopics = parsed.KeyTopics[:domain.MaxTopicsCount]
+	}
+
+	// Clean up topics
+	for i, topic := range parsed.KeyTopics {
+		topic = strings.TrimSpace(strings.ToLower(topic))
+		topic = strings.ReplaceAll(topic, " ", "_")
+		parsed.KeyTopics[i] = topic
+	}
+
+	return &parsed, nil
+}
+
+// GetSummary retrieves a single summary by ID.
+func (s *ConversationSummarizerService) GetSummary(ctx context.Context, summaryID string) (*domain.ConversationSummary, error) {
+	return s.summaries.GetByID(ctx, summaryID)
+}
+
+// GetSummariesByUser retrieves all summaries for a user.
+func (s *ConversationSummarizerService) GetSummariesByUser(ctx context.Context, userID string, limit int) ([]domain.ConversationSummary, error) {
+	if limit <= 0 {
+		limit = s.maxSummaries
+	}
+	return s.summaries.GetByUserID(ctx, userID, limit)
+}
+
+// ListSummaries retrieves summaries with filtering and pagination.
+func (s *ConversationSummarizerService) ListSummaries(ctx context.Context, filter domain.ConversationSummaryFilter) ([]domain.ConversationSummary, int, error) {
+	if filter.UserID == "" {
+		return nil, 0, &domain.ValidationError{Field: "user_id", Message: "required"}
+	}
+	return s.summaries.List(ctx, filter)
+}
+
+// DeleteSummary deletes a summary by ID.
+func (s *ConversationSummarizerService) DeleteSummary(ctx context.Context, summaryID string) error {
+	return s.summaries.Delete(ctx, summaryID)
+}
+
+// CountSummariesByUser returns the count of summaries for a user.
+func (s *ConversationSummarizerService) CountSummariesByUser(ctx context.Context, userID string) (int, error) {
+	return s.summaries.CountByUserID(ctx, userID)
+}
+
+// HasLLM returns true if an LLM client is configured.
+func (s *ConversationSummarizerService) HasLLM() bool {
+	return s.llm != nil
+}
+
+// formatConversationForSummary formats messages into a conversation string for summarization.
+func formatConversationForSummary(messages []domain.SummaryMessage) string {
+	var sb strings.Builder
+	for _, msg := range messages {
+		role := msg.Role
+		if r, _ := utf8.DecodeRuneInString(role); r != utf8.RuneError {
+			role = strings.ToUpper(string(r)) + role[utf8.RuneLen(r):]
+		}
+		sb.WriteString(role)
+		sb.WriteString(": ")
+		sb.WriteString(msg.Content)
+		sb.WriteString("\n\n")
+	}
+	return strings.TrimSpace(sb.String())
+}

--- a/server/internal/service/conversation_summarizer_test.go
+++ b/server/internal/service/conversation_summarizer_test.go
@@ -1,0 +1,428 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/devioslang/memorix/server/internal/domain"
+)
+
+// summaryTestRepo is a mock implementation of repository.ConversationSummaryRepo for testing
+type summaryTestRepo struct {
+	summaries map[string]*domain.ConversationSummary
+	byUser    map[string][]*domain.ConversationSummary
+	bySession map[string]*domain.ConversationSummary
+	count     int
+	createErr error
+	getErr    error
+	deleteErr error
+}
+
+func newSummaryTestRepo() *summaryTestRepo {
+	return &summaryTestRepo{
+		summaries: make(map[string]*domain.ConversationSummary),
+		byUser:    make(map[string][]*domain.ConversationSummary),
+		bySession: make(map[string]*domain.ConversationSummary),
+	}
+}
+
+func (m *summaryTestRepo) Create(ctx context.Context, summary *domain.ConversationSummary) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.summaries[summary.SummaryID] = summary
+	m.byUser[summary.UserID] = append(m.byUser[summary.UserID], summary)
+	if summary.SessionID != "" {
+		m.bySession[summary.SessionID] = summary
+	}
+	m.count++
+	return nil
+}
+
+func (m *summaryTestRepo) GetByID(ctx context.Context, summaryID string) (*domain.ConversationSummary, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	if s, ok := m.summaries[summaryID]; ok {
+		return s, nil
+	}
+	return nil, domain.ErrNotFound
+}
+
+func (m *summaryTestRepo) GetByUserID(ctx context.Context, userID string, limit int) ([]domain.ConversationSummary, error) {
+	summaries := m.byUser[userID]
+	if len(summaries) > limit {
+		summaries = summaries[:limit]
+	}
+	result := make([]domain.ConversationSummary, len(summaries))
+	for i, s := range summaries {
+		result[i] = *s
+	}
+	return result, nil
+}
+
+func (m *summaryTestRepo) GetBySessionID(ctx context.Context, sessionID string) (*domain.ConversationSummary, error) {
+	if s, ok := m.bySession[sessionID]; ok {
+		return s, nil
+	}
+	return nil, domain.ErrNotFound
+}
+
+func (m *summaryTestRepo) List(ctx context.Context, f domain.ConversationSummaryFilter) ([]domain.ConversationSummary, int, error) {
+	summaries := m.byUser[f.UserID]
+	result := make([]domain.ConversationSummary, len(summaries))
+	for i, s := range summaries {
+		result[i] = *s
+	}
+	return result, len(summaries), nil
+}
+
+func (m *summaryTestRepo) Delete(ctx context.Context, summaryID string) error {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	if s, ok := m.summaries[summaryID]; ok {
+		delete(m.summaries, summaryID)
+		m.count--
+		userSummaries := m.byUser[s.UserID]
+		for i, us := range userSummaries {
+			if us.SummaryID == summaryID {
+				m.byUser[s.UserID] = append(userSummaries[:i], userSummaries[i+1:]...)
+				break
+			}
+		}
+		if s.SessionID != "" {
+			delete(m.bySession, s.SessionID)
+		}
+		return nil
+	}
+	return domain.ErrNotFound
+}
+
+func (m *summaryTestRepo) DeleteOldest(ctx context.Context, userID string, count int) (int64, error) {
+	if m.deleteErr != nil {
+		return 0, m.deleteErr
+	}
+	userSummaries := m.byUser[userID]
+	if len(userSummaries) <= count {
+		for _, s := range userSummaries {
+			delete(m.summaries, s.SummaryID)
+			if s.SessionID != "" {
+				delete(m.bySession, s.SessionID)
+			}
+			m.count--
+		}
+		deleted := int64(len(userSummaries))
+		m.byUser[userID] = nil
+		return deleted, nil
+	}
+	for i := 0; i < count; i++ {
+		s := userSummaries[i]
+		delete(m.summaries, s.SummaryID)
+		if s.SessionID != "" {
+			delete(m.bySession, s.SessionID)
+		}
+		m.count--
+	}
+	m.byUser[userID] = userSummaries[count:]
+	return int64(count), nil
+}
+
+func (m *summaryTestRepo) CountByUserID(ctx context.Context, userID string) (int, error) {
+	return len(m.byUser[userID]), nil
+}
+
+// summaryTestLLM is a mock LLM client for summarizer tests
+type summaryTestLLM struct {
+	response string
+	err      error
+}
+
+func (m *summaryTestLLM) Complete(ctx context.Context, system, user string) (string, error) {
+	return m.response, m.err
+}
+
+func (m *summaryTestLLM) CompleteJSON(ctx context.Context, system, user string) (string, error) {
+	return m.response, m.err
+}
+
+func TestSummarize_Success(t *testing.T) {
+	repo := newSummaryTestRepo()
+	llm := &summaryTestLLM{
+		response: `{
+			"title": "Go channels discussion",
+			"summary": "Discussed Go channels, buffered vs unbuffered differences.",
+			"key_topics": ["go", "concurrency", "channels"],
+			"user_intent": "Learn Go channel patterns"
+		}`,
+	}
+	svc := NewConversationSummarizerService(repo, llm, 20)
+
+	req := SummarizeRequest{
+		UserID:    "user-123",
+		SessionID: "session-456",
+		Messages: []domain.SummaryMessage{
+			{Role: "user", Content: "What are Go channels?"},
+			{Role: "assistant", Content: "Go channels are a concurrency primitive..."},
+		},
+	}
+
+	result, err := svc.Summarize(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Summarize failed: %v", err)
+	}
+
+	if result.Status != "complete" {
+		t.Errorf("expected status 'complete', got '%s'", result.Status)
+	}
+	if result.SummaryID == "" {
+		t.Error("expected summary_id to be set")
+	}
+	if result.Skipped {
+		t.Error("expected skipped to be false")
+	}
+	if result.Summary == nil {
+		t.Fatal("expected summary to be set")
+	}
+	if result.Summary.Title != "Go channels discussion" {
+		t.Errorf("expected title 'Go channels discussion', got '%s'", result.Summary.Title)
+	}
+}
+
+func TestSummarize_SkipExisting(t *testing.T) {
+	repo := newSummaryTestRepo()
+	existing := &domain.ConversationSummary{
+		SummaryID:  "existing-id",
+		UserID:     "user-123",
+		SessionID:  "session-456",
+		Title:      "Existing summary",
+		Summary:    "This already exists",
+		KeyTopics:  []string{"existing"},
+		UserIntent: "Already summarized",
+	}
+	repo.Create(context.Background(), existing)
+
+	llm := &summaryTestLLM{
+		response: `{"title": "New", "summary": "New summary", "key_topics": [], "user_intent": "New"}`,
+	}
+	svc := NewConversationSummarizerService(repo, llm, 20)
+
+	req := SummarizeRequest{
+		UserID:    "user-123",
+		SessionID: "session-456",
+		Messages: []domain.SummaryMessage{
+			{Role: "user", Content: "New message"},
+		},
+	}
+
+	result, err := svc.Summarize(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Summarize failed: %v", err)
+	}
+
+	if !result.Skipped {
+		t.Error("expected skipped to be true")
+	}
+	if result.SummaryID != "existing-id" {
+		t.Errorf("expected existing summary_id, got '%s'", result.SummaryID)
+	}
+	if repo.count != 1 {
+		t.Errorf("expected 1 summary, got %d", repo.count)
+	}
+}
+
+func TestSummarize_ValidationError(t *testing.T) {
+	repo := newSummaryTestRepo()
+	llm := &summaryTestLLM{}
+	svc := NewConversationSummarizerService(repo, llm, 20)
+
+	// Missing user_id
+	req := SummarizeRequest{
+		SessionID: "session-456",
+		Messages: []domain.SummaryMessage{
+			{Role: "user", Content: "Test"},
+		},
+	}
+
+	_, err := svc.Summarize(context.Background(), req)
+	if err == nil {
+		t.Error("expected error for missing user_id")
+	}
+
+	// Empty messages
+	req2 := SummarizeRequest{
+		UserID: "user-123",
+	}
+	_, err = svc.Summarize(context.Background(), req2)
+	if err == nil {
+		t.Error("expected error for missing messages")
+	}
+}
+
+func TestSummarize_SlidingWindow(t *testing.T) {
+	repo := newSummaryTestRepo()
+	llm := &summaryTestLLM{
+		response: `{
+			"title": "Test",
+			"summary": "Test summary",
+			"key_topics": ["test"],
+			"user_intent": "Testing"
+		}`,
+	}
+	svc := NewConversationSummarizerService(repo, llm, 3) // Small limit for testing
+
+	// Create 3 summaries (at capacity)
+	for i := 0; i < 3; i++ {
+		req := SummarizeRequest{
+			UserID:    "user-123",
+			SessionID: string(rune('a' + i)),
+			Messages: []domain.SummaryMessage{
+				{Role: "user", Content: "Test"},
+			},
+		}
+		_, err := svc.Summarize(context.Background(), req)
+		if err != nil {
+			t.Fatalf("Summarize failed: %v", err)
+		}
+	}
+
+	// Now create one more - should trigger deletion of oldest
+	req := SummarizeRequest{
+		UserID:    "user-123",
+		SessionID: "new-session",
+		Messages: []domain.SummaryMessage{
+			{Role: "user", Content: "Test"},
+		},
+	}
+	result, err := svc.Summarize(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Summarize failed: %v", err)
+	}
+
+	if result.Status != "complete" {
+		t.Errorf("expected status 'complete', got '%s'", result.Status)
+	}
+
+	// Should still have 3 summaries (sliding window enforced)
+	count, _ := repo.CountByUserID(context.Background(), "user-123")
+	if count != 3 {
+		t.Errorf("expected 3 summaries, got %d", count)
+	}
+}
+
+func TestSummarize_NoLLM(t *testing.T) {
+	repo := newSummaryTestRepo()
+	svc := NewConversationSummarizerService(repo, nil, 20) // No LLM client
+
+	req := SummarizeRequest{
+		UserID:    "user-123",
+		SessionID: "session-456",
+		Messages: []domain.SummaryMessage{
+			{Role: "user", Content: "Test"},
+		},
+	}
+
+	result, err := svc.Summarize(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Summarize failed: %v", err)
+	}
+
+	if result.Status != "failed" {
+		t.Errorf("expected status 'failed', got '%s'", result.Status)
+	}
+	if result.Error != "LLM client not configured" {
+		t.Errorf("expected LLM error, got '%s'", result.Error)
+	}
+}
+
+func TestGetSummary(t *testing.T) {
+	repo := newSummaryTestRepo()
+	llm := &summaryTestLLM{}
+	svc := NewConversationSummarizerService(repo, llm, 20)
+
+	summary := &domain.ConversationSummary{
+		SummaryID:  "test-id",
+		UserID:     "user-123",
+		Title:      "Test",
+		Summary:    "Test summary",
+		KeyTopics:  []string{"test"},
+		UserIntent: "Testing",
+	}
+	repo.Create(context.Background(), summary)
+
+	result, err := svc.GetSummary(context.Background(), "test-id")
+	if err != nil {
+		t.Fatalf("GetSummary failed: %v", err)
+	}
+
+	if result.SummaryID != "test-id" {
+		t.Errorf("expected summary_id 'test-id', got '%s'", result.SummaryID)
+	}
+}
+
+func TestGetSummariesByUser(t *testing.T) {
+	repo := newSummaryTestRepo()
+	llm := &summaryTestLLM{}
+	svc := NewConversationSummarizerService(repo, llm, 20)
+
+	for i := 0; i < 5; i++ {
+		summary := &domain.ConversationSummary{
+			SummaryID:  string(rune('a' + i)),
+			UserID:     "user-123",
+			Title:      "Test",
+			Summary:    "Test summary",
+			KeyTopics:  []string{"test"},
+			UserIntent: "Testing",
+		}
+		repo.Create(context.Background(), summary)
+	}
+
+	result, err := svc.GetSummariesByUser(context.Background(), "user-123", 3)
+	if err != nil {
+		t.Fatalf("GetSummariesByUser failed: %v", err)
+	}
+
+	if len(result) != 3 {
+		t.Errorf("expected 3 summaries, got %d", len(result))
+	}
+}
+
+func TestDeleteSummary(t *testing.T) {
+	repo := newSummaryTestRepo()
+	llm := &summaryTestLLM{}
+	svc := NewConversationSummarizerService(repo, llm, 20)
+
+	summary := &domain.ConversationSummary{
+		SummaryID:  "test-id",
+		UserID:     "user-123",
+		Title:      "Test",
+		Summary:    "Test summary",
+		KeyTopics:  []string{"test"},
+		UserIntent: "Testing",
+	}
+	repo.Create(context.Background(), summary)
+
+	err := svc.DeleteSummary(context.Background(), "test-id")
+	if err != nil {
+		t.Fatalf("DeleteSummary failed: %v", err)
+	}
+
+	_, err = svc.GetSummary(context.Background(), "test-id")
+	if err == nil {
+		t.Error("expected error after deletion")
+	}
+}
+
+func TestSummarizerHasLLM(t *testing.T) {
+	repo := newSummaryTestRepo()
+
+	svc := NewConversationSummarizerService(repo, &summaryTestLLM{}, 20)
+	if !svc.HasLLM() {
+		t.Error("expected HasLLM to return true")
+	}
+
+	svc2 := NewConversationSummarizerService(repo, nil, 20)
+	if svc2.HasLLM() {
+		t.Error("expected HasLLM to return false")
+	}
+}

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -177,3 +177,24 @@ CREATE TABLE IF NOT EXISTS reconcile_audit_logs (
   INDEX idx_fact_audit (fact_id, created_at DESC),
   INDEX idx_category_audit (user_id, category, created_at DESC)
 );
+
+-- Conversation summaries (recent conversation summary layer).
+-- Based on ChatGPT's "fourth layer" - pre-computed summaries of recent conversations.
+-- Advantages: zero retrieval latency, provides quick context for ongoing conversations.
+CREATE TABLE IF NOT EXISTS conversation_summaries (
+  summary_id     VARCHAR(36)     PRIMARY KEY,
+  user_id        VARCHAR(100)    NOT NULL,
+  session_id     VARCHAR(100)    NULL
+                 COMMENT 'Session ID this summary originated from',
+  title          VARCHAR(200)    NOT NULL
+                 COMMENT 'LLM-generated conversation title',
+  summary        VARCHAR(500)    NOT NULL
+                 COMMENT 'Summary within 200 Chinese characters (~500 bytes)',
+  key_topics     JSON            NULL
+                 COMMENT 'Array of key topic tags',
+  user_intent    VARCHAR(300)    NOT NULL
+                 COMMENT 'Core user intent from conversation',
+  created_at     TIMESTAMP       DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_user_summaries (user_id, created_at DESC),
+  INDEX idx_session (session_id)
+) COMMENT 'Recent conversation summaries - sliding window of 15-20 per user';


### PR DESCRIPTION
## Summary

Implements the "fourth layer" of ChatGPT's memory system - recent conversation summaries - as described in Issue #7.

### Key Components

1. **Domain Model** (`conversation_summary.go`)
   - `ConversationSummary` struct with: summary_id, user_id, session_id, title, summary, key_topics, user_intent, created_at
   - Constants for sliding window limits (15-20 summaries per user)

2. **Database Schema** (`schema.sql`)
   - `conversation_summaries` table with proper indexes
   - Supports efficient user_id queries and sliding window management

3. **Repository Layer** (`repository.go`, `tidb/conversation_summary.go`)
   - `ConversationSummaryRepo` interface with CRUD operations
   - `DeleteOldest` for sliding window enforcement
   - TiDB implementation with JSON handling for key_topics

4. **Service Layer** (`conversation_summarizer.go`)
   - `ConversationSummarizerService` with LLM-based summary generation
   - Structured prompt for bilingual support (Chinese/English)
   - Automatic sliding window maintenance (deletes oldest when at capacity)
   - Duplicate detection via session_id

5. **HTTP Handler** (`conversation_summary.go`)
   - `POST /summaries` - Generate and store summary
   - `GET /summaries` - List summaries for user
   - `GET /summaries/{id}` - Get single summary
   - `DELETE /summaries/{id}` - Delete summary

### Features

- **Zero retrieval latency**: Pre-computed summaries stored in database
- **LLM-generated content**: Title, summary (≤200 chars), key topics, user intent
- **Sliding window**: Maintains 15-20 summaries per user (configurable)
- **Bilingual support**: Chinese and English prompts for summary generation
- **Idempotency**: Skips if summary already exists for session

## Test Plan

- [x] Unit tests for ConversationSummarizerService
- [x] Tests cover: success case, skip existing, validation errors, sliding window, no LLM client
- [x] `make vet` passes
- [x] `go build ./...` passes

Closes #7