### PR TITLE
feat: implement Hybrid Retriever for multi-layer memory retrieval

### DIFF
--- a/server/internal/domain/hybrid_retriever.go
+++ b/server/internal/domain/hybrid_retriever.go
@@ -1,0 +1,269 @@
+package domain
+
+import (
+	"time"
+)
+
+// HybridRetrieverResult represents a single retrieved item with comprehensive metadata.
+// It provides full tracing information about which layer the result came from,
+// how it was scored, and how it was combined with other results.
+type HybridRetrieverResult struct {
+	// ID is the unique identifier for the result.
+	// For UserProfileFact: FactID
+	// For ConversationSummary: SummaryID
+	// For Experience: ExperienceID
+	ID string `json:"id"`
+
+	// Content is the textual content of the result.
+	Content string `json:"content"`
+
+	// SourceLayer indicates which memory layer this result came from.
+	SourceLayer RetrievalSourceLayer `json:"source_layer"`
+
+	// SourceType indicates the type of data within the layer.
+	// For LayerUserProfile: "fact"
+	// For LayerConversationSummary: "summary"
+	// For LayerExperience: "experience"
+	SourceType string `json:"source_type"`
+
+	// ScoreBreakdown contains the detailed scoring components.
+	ScoreBreakdown ScoreBreakdown `json:"score_breakdown"`
+
+	// FinalScore is the weighted combination of all score components.
+	FinalScore float64 `json:"final_score"`
+
+	// Metadata contains additional context-specific metadata.
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+
+	// TokenCount is the estimated token count of the content.
+	TokenCount int `json:"token_count"`
+
+	// CreatedAt is when this item was originally created.
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// RetrievalSourceLayer identifies the source memory layer for a result.
+type RetrievalSourceLayer string
+
+const (
+	// RetrievalLayerUserProfile represents the User Profile Store (first layer).
+	// Contains structured facts about the user: name, preferences, goals.
+	// Retrieval: exact match on key/category.
+	RetrievalLayerUserProfile RetrievalSourceLayer = "user_profile"
+
+	// RetrievalLayerConversationSummary represents the Conversation Summary Pool (second layer).
+	// Contains pre-computed summaries of recent conversations.
+	// Retrieval: keyword match + time range filter.
+	RetrievalLayerConversationSummary RetrievalSourceLayer = "conversation_summary"
+
+	// RetrievalLayerExperience represents the Vector Store (third layer).
+	// Contains semantic experiences extracted from past conversations.
+	// Retrieval: semantic similarity (cosine distance).
+	RetrievalLayerExperience RetrievalSourceLayer = "experience"
+)
+
+// ScoreBreakdown contains the detailed components of a result's score.
+// Final score = w1 * ExactMatchScore + w2 * SemanticScore + w3 * TimeDecayScore + w4 * ImportanceScore
+type ScoreBreakdown struct {
+	// ExactMatchScore is 1.0 if the query exactly matches a key/category in user profile.
+	// For other layers, this is 0.0.
+	ExactMatchScore float64 `json:"exact_match_score"`
+
+	// SemanticScore is the cosine similarity from vector search.
+	// For user profile (exact match), this is 1.0.
+	// For conversation summary, this is keyword overlap score (0-1).
+	// For experience, this is the actual cosine similarity.
+	SemanticScore float64 `json:"semantic_score"`
+
+	// TimeDecayScore represents recency: newer items score higher.
+	// Calculated as: exp(-decay_rate * hours_since_creation)
+	// Range: 0.0 (very old) to 1.0 (just created).
+	TimeDecayScore float64 `json:"time_decay_score"`
+
+	// ImportanceScore represents the inherent importance of the item.
+	// For user profile: confidence field
+	// For experience: confidence field from metadata
+	// For conversation summary: derived from key topics count
+	ImportanceScore float64 `json:"importance_score"`
+
+	// Individual weights applied during scoring (for tracing).
+	Weights ScoringWeights `json:"weights"`
+}
+
+// ScoringWeights contains the weights used for combining scores.
+type ScoringWeights struct {
+	W1ExactMatch  float64 `json:"w1_exact_match"`
+	W2Semantic    float64 `json:"w2_semantic"`
+	W3TimeDecay   float64 `json:"w3_time_decay"`
+	W4Importance  float64 `json:"w4_importance"`
+}
+
+// HybridRetrievalContext contains additional context for retrieval.
+type HybridRetrievalContext struct {
+	// SessionID is the current session identifier.
+	SessionID string `json:"session_id,omitempty"`
+
+	// MaxTokens is the maximum total tokens for the result set.
+	// Results will be trimmed to fit within this budget.
+	MaxTokens int `json:"max_tokens,omitempty"`
+
+	// TimeRange limits results to a specific time window.
+	// Only results within this range will be considered.
+	TimeRange *TimeRange `json:"time_range,omitempty"`
+
+	// Categories filters user profile results by category.
+	Categories []FactCategory `json:"categories,omitempty"`
+
+	// Topics filters experience results by topic.
+	Topics []string `json:"topics,omitempty"`
+
+	// MinScore sets a minimum score threshold for results.
+	MinScore float64 `json:"min_score,omitempty"`
+
+	// TopK sets the maximum number of results per layer.
+	TopK int `json:"top_k,omitempty"`
+
+	// IncludeLayers specifies which layers to include in retrieval.
+	// If empty, all layers are included.
+	IncludeLayers []RetrievalSourceLayer `json:"include_layers,omitempty"`
+
+	// CustomWeights allows overriding default scoring weights.
+	CustomWeights *ScoringWeights `json:"custom_weights,omitempty"`
+
+	// TimeDecayRate controls how quickly scores decay with time.
+	// Default: 0.001 (slow decay). Higher = faster decay.
+	TimeDecayRate float64 `json:"time_decay_rate,omitempty"`
+}
+
+// TimeRange specifies a time window for filtering results.
+type TimeRange struct {
+	// Start is the start of the time range (inclusive).
+	Start time.Time `json:"start"`
+
+	// End is the end of the time range (inclusive).
+	End time.Time `json:"end"`
+}
+
+// HybridRetrievalResult contains the complete retrieval result with tracing.
+type HybridRetrievalResult struct {
+	// Results is the deduplicated, sorted list of retrieved items.
+	Results []HybridRetrieverResult `json:"results"`
+
+	// TotalTokens is the sum of all result token counts.
+	TotalTokens int `json:"total_tokens"`
+
+	// MaxTokens is the token budget that was used.
+	MaxTokens int `json:"max_tokens"`
+
+	// Truncated indicates whether results were trimmed to fit budget.
+	Truncated bool `json:"truncated"`
+
+	// LayerStatistics contains per-layer retrieval statistics.
+	LayerStatistics []LayerRetrievalStats `json:"layer_statistics"`
+
+	// RetrievalTrace contains detailed tracing information.
+	RetrievalTrace RetrievalTrace `json:"retrieval_trace"`
+
+	// Query is the original query string.
+	Query string `json:"query"`
+
+	// UserID is the user ID for this retrieval.
+	UserID string `json:"user_id"`
+
+	// LatencyMs is the total retrieval latency in milliseconds.
+	LatencyMs int64 `json:"latency_ms"`
+}
+
+// LayerRetrievalStats contains statistics for a single layer retrieval.
+type LayerRetrievalStats struct {
+	// Layer identifies the retrieval layer.
+	Layer RetrievalSourceLayer `json:"layer"`
+
+	// CandidatesFound is the number of items found before deduplication.
+	CandidatesFound int `json:"candidates_found"`
+
+	// CandidatesReturned is the number of items returned after deduplication.
+	CandidatesReturned int `json:"candidates_returned"`
+
+	// AvgScore is the average score of returned items.
+	AvgScore float64 `json:"avg_score"`
+
+	// LatencyMs is the retrieval latency for this layer.
+	LatencyMs int64 `json:"latency_ms"`
+
+	// Error contains any error that occurred during retrieval.
+	Error string `json:"error,omitempty"`
+}
+
+// RetrievalTrace contains detailed tracing information for debugging.
+type RetrievalTrace struct {
+	// QueryIntent is the detected intent of the query.
+	// "exact_fact": Query seeks a specific fact (e.g., "What's my name?")
+	// "semantic": Query seeks related experiences (e.g., "discussed architecture")
+	// "hybrid": Query combines both
+	QueryIntent string `json:"query_intent"`
+
+	// ExtractedKeywords contains keywords extracted from the query.
+	ExtractedKeywords []string `json:"extracted_keywords,omitempty"`
+
+	// DetectedCategories contains categories detected from the query.
+	// Used for user profile retrieval.
+	DetectedCategories []FactCategory `json:"detected_categories,omitempty"`
+
+	// DeduplicationStats contains information about deduplication.
+	DeduplicationStats DeduplicationStats `json:"deduplication_stats"`
+
+	// ScoringDetails contains additional scoring details.
+	ScoringDetails string `json:"scoring_details,omitempty"`
+}
+
+// DeduplicationStats contains statistics about the deduplication process.
+type DeduplicationStats struct {
+	// TotalCandidates is the total number of candidates before deduplication.
+	TotalCandidates int `json:"total_candidates"`
+
+	// DuplicatesRemoved is the number of duplicates removed.
+	DuplicatesRemoved int `json:"duplicates_removed"`
+
+	// DeduplicationMethod describes how duplicates were identified.
+	DeduplicationMethod string `json:"deduplication_method"`
+}
+
+// HybridRetrieverConfig contains configuration for the hybrid retriever.
+type HybridRetrieverConfig struct {
+	// DefaultTopK is the default number of results per layer.
+	DefaultTopK int `json:"default_top_k"`
+
+	// DefaultMaxTokens is the default token budget.
+	DefaultMaxTokens int `json:"default_max_tokens"`
+
+	// DefaultMinScore is the default minimum score threshold.
+	DefaultMinScore float64 `json:"default_min_score"`
+
+	// DefaultWeights are the default scoring weights.
+	DefaultWeights ScoringWeights `json:"default_weights"`
+
+	// DefaultTimeDecayRate is the default time decay rate.
+	DefaultTimeDecayRate float64 `json:"default_time_decay_rate"`
+
+	// SummaryTimeRangeHours limits conversation summary retrieval to recent hours.
+	// Default: 168 (7 days).
+	SummaryTimeRangeHours int `json:"summary_time_range_hours"`
+}
+
+// DefaultHybridRetrieverConfig returns sensible defaults.
+func DefaultHybridRetrieverConfig() HybridRetrieverConfig {
+	return HybridRetrieverConfig{
+		DefaultTopK:            10,
+		DefaultMaxTokens:       2000,
+		DefaultMinScore:        0.3,
+		DefaultTimeDecayRate:   0.001, // Slow decay
+		SummaryTimeRangeHours: 168,    // 7 days
+		DefaultWeights: ScoringWeights{
+			W1ExactMatch: 0.4,
+			W2Semantic:   0.3,
+			W3TimeDecay:  0.15,
+			W4Importance: 0.15,
+		},
+	}
+}

--- a/server/internal/service/hybrid_retriever.go
+++ b/server/internal/service/hybrid_retriever.go
@@ -1,0 +1,851 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/devioslang/memorix/server/internal/domain"
+	"github.com/devioslang/memorix/server/internal/repository"
+	"github.com/devioslang/memorix/server/internal/tokenizer"
+	"github.com/devioslang/memorix/server/internal/vectorstore"
+)
+
+// HybridRetriever implements a multi-layer retrieval strategy that combines
+// results from User Profile Store, Conversation Summary Pool, and Vector Store.
+//
+// Retrieval Order (priority):
+// 1. User Profile Store - Exact match on key/category
+// 2. Conversation Summary Pool - Keyword + time range
+// 3. Vector Store (Experience) - Semantic similarity
+//
+// Scoring: FinalScore = w1*ExactMatch + w2*Semantic + w3*TimeDecay + w4*Importance
+type HybridRetriever struct {
+	userProfileRepo  repository.UserProfileFactRepo
+	summaryRepo      repository.ConversationSummaryRepo
+	experienceStore  vectorstore.VectorStore
+	config           domain.HybridRetrieverConfig
+	tokenizer        tokenizer.Tokenizer
+	embedder         Embedder
+}
+
+// Embedder interface for generating query embeddings.
+type Embedder interface {
+	Embed(ctx context.Context, text string) ([]float32, error)
+}
+
+// NewHybridRetriever creates a new HybridRetriever instance.
+func NewHybridRetriever(
+	userProfileRepo repository.UserProfileFactRepo,
+	summaryRepo repository.ConversationSummaryRepo,
+	experienceStore vectorstore.VectorStore,
+	embedder Embedder,
+	config domain.HybridRetrieverConfig,
+) *HybridRetriever {
+	if config.DefaultTopK <= 0 {
+		config.DefaultTopK = 10
+	}
+	if config.DefaultMaxTokens <= 0 {
+		config.DefaultMaxTokens = 2000
+	}
+	if config.DefaultTimeDecayRate <= 0 {
+		config.DefaultTimeDecayRate = 0.001
+	}
+	if config.SummaryTimeRangeHours <= 0 {
+		config.SummaryTimeRangeHours = 168
+	}
+	if config.DefaultWeights.W1ExactMatch+config.DefaultWeights.W2Semantic+
+		config.DefaultWeights.W3TimeDecay+config.DefaultWeights.W4Importance == 0 {
+		config.DefaultWeights = domain.DefaultHybridRetrieverConfig().DefaultWeights
+	}
+
+	return &HybridRetriever{
+		userProfileRepo:  userProfileRepo,
+		summaryRepo:      summaryRepo,
+		experienceStore:  experienceStore,
+		embedder:         embedder,
+		config:           config,
+		tokenizer:        tokenizer.NewDefault(),
+	}
+}
+
+// Retrieve performs hybrid retrieval across all memory layers.
+// The retrieval strategy follows a priority order:
+// 1. User Profile Store - Exact match for factual queries
+// 2. Conversation Summary Pool - Keyword match for recent context
+// 3. Vector Store - Semantic similarity for related experiences
+//
+// Results are merged, deduplicated, scored, and trimmed to fit the token budget.
+func (r *HybridRetriever) Retrieve(
+	ctx context.Context,
+	userID string,
+	query string,
+	retrievalCtx *domain.HybridRetrievalContext,
+) (*domain.HybridRetrievalResult, error) {
+	startTime := time.Now()
+
+	// Apply defaults to retrieval context
+	if retrievalCtx == nil {
+		retrievalCtx = &domain.HybridRetrievalContext{}
+	}
+	topK := retrievalCtx.TopK
+	if topK <= 0 {
+		topK = r.config.DefaultTopK
+	}
+	maxTokens := retrievalCtx.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = r.config.DefaultMaxTokens
+	}
+	minScore := retrievalCtx.MinScore
+	if minScore == 0 {
+		minScore = r.config.DefaultMinScore
+	}
+	timeDecayRate := retrievalCtx.TimeDecayRate
+	if timeDecayRate <= 0 {
+		timeDecayRate = r.config.DefaultTimeDecayRate
+	}
+
+	// Get scoring weights
+	weights := r.config.DefaultWeights
+	if retrievalCtx.CustomWeights != nil {
+		weights = *retrievalCtx.CustomWeights
+	}
+
+	// Detect query intent
+	queryIntent := r.detectQueryIntent(query)
+	keywords := r.extractKeywords(query)
+	detectedCategories := r.detectCategories(query)
+
+	slog.Info("hybrid retrieval started",
+		"user_id", userID,
+		"query", query,
+		"intent", queryIntent,
+		"keywords", keywords,
+		"top_k", topK,
+		"max_tokens", maxTokens,
+	)
+
+	// Initialize result tracking
+	var allResults []domain.HybridRetrieverResult
+	var layerStats []domain.LayerRetrievalStats
+	trace := domain.RetrievalTrace{
+		QueryIntent:         queryIntent,
+		ExtractedKeywords:   keywords,
+		DetectedCategories:  detectedCategories,
+		DeduplicationStats:  domain.DeduplicationStats{},
+	}
+
+	// Layer 1: User Profile Store (exact match)
+	if r.shouldSearchLayer(domain.RetrievalLayerUserProfile, retrievalCtx.IncludeLayers) {
+		profileResults, profileStats := r.retrieveFromUserProfile(
+			ctx, userID, query, detectedCategories, weights, timeDecayRate,
+		)
+		allResults = append(allResults, profileResults...)
+		layerStats = append(layerStats, profileStats)
+	}
+
+	// Layer 2: Conversation Summary Pool (keyword + time range)
+	if r.shouldSearchLayer(domain.RetrievalLayerConversationSummary, retrievalCtx.IncludeLayers) {
+		summaryResults, summaryStats := r.retrieveFromConversationSummary(
+			ctx, userID, query, keywords, retrievalCtx.TimeRange, weights, timeDecayRate, topK,
+		)
+		allResults = append(allResults, summaryResults...)
+		layerStats = append(layerStats, summaryStats)
+	}
+
+	// Layer 3: Vector Store (semantic similarity)
+	if r.shouldSearchLayer(domain.RetrievalLayerExperience, retrievalCtx.IncludeLayers) && r.experienceStore != nil {
+		expResults, expStats := r.retrieveFromExperience(
+			ctx, userID, query, retrievalCtx, weights, timeDecayRate, topK, minScore,
+		)
+		allResults = append(allResults, expResults...)
+		layerStats = append(layerStats, expStats)
+	}
+
+	// Deduplicate and sort
+	trace.DeduplicationStats.TotalCandidates = len(allResults)
+	dedupedResults := r.deduplicateResults(allResults)
+	trace.DeduplicationStats.DuplicatesRemoved = len(allResults) - len(dedupedResults)
+	trace.DeduplicationStats.DeduplicationMethod = "content_similarity"
+
+	// Sort by final score (descending)
+	r.sortResultsByScore(dedupedResults)
+
+	// Trim to token budget
+	totalTokens := r.calculateTotalTokens(dedupedResults)
+	truncated := false
+	if totalTokens > maxTokens {
+		dedupedResults = r.trimToTokenBudget(dedupedResults, maxTokens)
+		totalTokens = r.calculateTotalTokens(dedupedResults)
+		truncated = true
+	}
+
+	latency := time.Since(startTime).Milliseconds()
+
+	slog.Info("hybrid retrieval completed",
+		"user_id", userID,
+		"query", query,
+		"total_candidates", trace.DeduplicationStats.TotalCandidates,
+		"duplicates_removed", trace.DeduplicationStats.DuplicatesRemoved,
+		"final_results", len(dedupedResults),
+		"total_tokens", totalTokens,
+		"truncated", truncated,
+		"latency_ms", latency,
+	)
+
+	return &domain.HybridRetrievalResult{
+		Results:          dedupedResults,
+		TotalTokens:      totalTokens,
+		MaxTokens:        maxTokens,
+		Truncated:        truncated,
+		LayerStatistics:  layerStats,
+		RetrievalTrace:   trace,
+		Query:            query,
+		UserID:           userID,
+		LatencyMs:        latency,
+	}, nil
+}
+
+// shouldSearchLayer checks if a layer should be searched.
+func (r *HybridRetriever) shouldSearchLayer(layer domain.RetrievalSourceLayer, includeLayers []domain.RetrievalSourceLayer) bool {
+	if len(includeLayers) == 0 {
+		return true
+	}
+	for _, l := range includeLayers {
+		if l == layer {
+			return true
+		}
+	}
+	return false
+}
+
+// retrieveFromUserProfile retrieves from User Profile Store.
+// Uses exact matching on key and category.
+func (r *HybridRetriever) retrieveFromUserProfile(
+	ctx context.Context,
+	userID string,
+	query string,
+	detectedCategories []domain.FactCategory,
+	weights domain.ScoringWeights,
+	timeDecayRate float64,
+) ([]domain.HybridRetrieverResult, domain.LayerRetrievalStats) {
+	startTime := time.Now()
+	var results []domain.HybridRetrieverResult
+
+	// Get all facts for user
+	facts, err := r.userProfileRepo.GetByUserID(ctx, userID)
+	if err != nil {
+		slog.Warn("failed to retrieve user profile facts", "user_id", userID, "err", err)
+		return results, domain.LayerRetrievalStats{
+			Layer:          domain.RetrievalLayerUserProfile,
+			CandidatesFound: 0,
+			Error:          err.Error(),
+			LatencyMs:      time.Since(startTime).Milliseconds(),
+		}
+	}
+
+	// Score each fact
+	queryLower := strings.ToLower(query)
+	for _, fact := range facts {
+		// Calculate exact match score
+		exactMatchScore := r.calculateExactMatchScore(queryLower, fact.Key, fact.Value, fact.Category)
+
+		// Skip if below threshold
+		if exactMatchScore < 0.5 {
+			continue
+		}
+
+		// Calculate time decay score
+		timeDecayScore := r.calculateTimeDecayScore(fact.CreatedAt, timeDecayRate)
+
+		// Calculate importance score (use confidence)
+		importanceScore := fact.Confidence
+
+		// Calculate final score
+		finalScore := weights.W1ExactMatch*exactMatchScore +
+			weights.W2Semantic*1.0 + // Exact match means high semantic relevance
+			weights.W3TimeDecay*timeDecayScore +
+			weights.W4Importance*importanceScore
+
+		content := fmt.Sprintf("[%s] %s: %s", fact.Category, fact.Key, fact.Value)
+		result := domain.HybridRetrieverResult{
+			ID:          fact.FactID,
+			Content:     content,
+			SourceLayer: domain.RetrievalLayerUserProfile,
+			SourceType:  "fact",
+			ScoreBreakdown: domain.ScoreBreakdown{
+				ExactMatchScore: exactMatchScore,
+				SemanticScore:   1.0,
+				TimeDecayScore:  timeDecayScore,
+				ImportanceScore: importanceScore,
+				Weights:         weights,
+			},
+			FinalScore: finalScore,
+			TokenCount: r.tokenizer.CountTokens(content),
+			CreatedAt:  fact.CreatedAt,
+			Metadata: map[string]interface{}{
+				"category":   string(fact.Category),
+				"key":        fact.Key,
+				"value":      fact.Value,
+				"confidence": fact.Confidence,
+				"source":     string(fact.Source),
+			},
+		}
+		results = append(results, result)
+	}
+
+	latency := time.Since(startTime).Milliseconds()
+	slog.Debug("user profile retrieval completed",
+		"user_id", userID,
+		"candidates", len(results),
+		"latency_ms", latency,
+	)
+
+	return results, domain.LayerRetrievalStats{
+		Layer:            domain.RetrievalLayerUserProfile,
+		CandidatesFound:  len(results),
+		CandidatesReturned: len(results),
+		AvgScore:         r.calculateAverageScore(results),
+		LatencyMs:        latency,
+	}
+}
+
+// retrieveFromConversationSummary retrieves from Conversation Summary Pool.
+// Uses keyword matching and time range filtering.
+func (r *HybridRetriever) retrieveFromConversationSummary(
+	ctx context.Context,
+	userID string,
+	query string,
+	keywords []string,
+	timeRange *domain.TimeRange,
+	weights domain.ScoringWeights,
+	timeDecayRate float64,
+	topK int,
+) ([]domain.HybridRetrieverResult, domain.LayerRetrievalStats) {
+	startTime := time.Now()
+	var results []domain.HybridRetrieverResult
+
+	// Determine time range
+	var startTimeFilter, endTimeFilter time.Time
+	if timeRange != nil {
+		startTimeFilter = timeRange.Start
+		endTimeFilter = timeRange.End
+	} else {
+		// Default to last N hours
+		endTimeFilter = time.Now()
+		startTimeFilter = endTimeFilter.Add(-time.Duration(r.config.SummaryTimeRangeHours) * time.Hour)
+	}
+
+	// Get summaries for user
+	summaries, err := r.summaryRepo.GetByUserID(ctx, userID, topK*2)
+	if err != nil {
+		slog.Warn("failed to retrieve conversation summaries", "user_id", userID, "err", err)
+		return results, domain.LayerRetrievalStats{
+			Layer:          domain.RetrievalLayerConversationSummary,
+			CandidatesFound: 0,
+			Error:          err.Error(),
+			LatencyMs:      time.Since(startTime).Milliseconds(),
+		}
+	}
+
+	// Score each summary
+	queryLower := strings.ToLower(query)
+	for _, summary := range summaries {
+		// Filter by time range
+		if summary.CreatedAt.Before(startTimeFilter) || summary.CreatedAt.After(endTimeFilter) {
+			continue
+		}
+
+		// Calculate keyword match score
+		semanticScore := r.calculateKeywordMatchScore(queryLower, keywords, summary)
+
+		// Skip if below threshold
+		if semanticScore < 0.2 {
+			continue
+		}
+
+		// Calculate time decay score
+		timeDecayScore := r.calculateTimeDecayScore(summary.CreatedAt, timeDecayRate)
+
+		// Calculate importance score based on key topics count
+		importanceScore := float64(len(summary.KeyTopics)) / 5.0
+		if importanceScore > 1.0 {
+			importanceScore = 1.0
+		}
+
+		// Calculate final score
+		finalScore := weights.W1ExactMatch*0.0 + // No exact match for summaries
+			weights.W2Semantic*semanticScore +
+			weights.W3TimeDecay*timeDecayScore +
+			weights.W4Importance*importanceScore
+
+		content := fmt.Sprintf("Title: %s\nSummary: %s\nTopics: %v\nUser Intent: %s",
+			summary.Title, summary.Summary, summary.KeyTopics, summary.UserIntent)
+
+		result := domain.HybridRetrieverResult{
+			ID:          summary.SummaryID,
+			Content:     content,
+			SourceLayer: domain.RetrievalLayerConversationSummary,
+			SourceType:  "summary",
+			ScoreBreakdown: domain.ScoreBreakdown{
+				ExactMatchScore: 0.0,
+				SemanticScore:   semanticScore,
+				TimeDecayScore:  timeDecayScore,
+				ImportanceScore: importanceScore,
+				Weights:         weights,
+			},
+			FinalScore: finalScore,
+			TokenCount: r.tokenizer.CountTokens(content),
+			CreatedAt:  summary.CreatedAt,
+			Metadata: map[string]interface{}{
+				"title":       summary.Title,
+				"key_topics":  summary.KeyTopics,
+				"user_intent": summary.UserIntent,
+				"session_id":  summary.SessionID,
+			},
+		}
+		results = append(results, result)
+	}
+
+	latency := time.Since(startTime).Milliseconds()
+	slog.Debug("conversation summary retrieval completed",
+		"user_id", userID,
+		"candidates", len(results),
+		"latency_ms", latency,
+	)
+
+	return results, domain.LayerRetrievalStats{
+		Layer:            domain.RetrievalLayerConversationSummary,
+		CandidatesFound:  len(results),
+		CandidatesReturned: len(results),
+		AvgScore:         r.calculateAverageScore(results),
+		LatencyMs:        latency,
+	}
+}
+
+// retrieveFromExperience retrieves from Vector Store (Experience).
+// Uses semantic similarity via vector search.
+func (r *HybridRetriever) retrieveFromExperience(
+	ctx context.Context,
+	userID string,
+	query string,
+	retrievalCtx *domain.HybridRetrievalContext,
+	weights domain.ScoringWeights,
+	timeDecayRate float64,
+	topK int,
+	minScore float64,
+) ([]domain.HybridRetrieverResult, domain.LayerRetrievalStats) {
+	startTime := time.Now()
+	var results []domain.HybridRetrieverResult
+
+	// Generate query embedding
+	if r.embedder == nil {
+		return results, domain.LayerRetrievalStats{
+			Layer:          domain.RetrievalLayerExperience,
+			CandidatesFound: 0,
+			Error:          "embedder not configured",
+			LatencyMs:      time.Since(startTime).Milliseconds(),
+		}
+	}
+
+	queryVec, err := r.embedder.Embed(ctx, query)
+	if err != nil {
+		slog.Warn("failed to embed query", "err", err)
+		return results, domain.LayerRetrievalStats{
+			Layer:          domain.RetrievalLayerExperience,
+			CandidatesFound: 0,
+			Error:          err.Error(),
+			LatencyMs:      time.Since(startTime).Milliseconds(),
+		}
+	}
+
+	// Build filter
+	filter := domain.ExperienceFilter{
+		UserID:   userID,
+		Query:    query,
+		MinScore: minScore,
+		Limit:    topK,
+	}
+	if retrievalCtx != nil && len(retrievalCtx.Topics) > 0 {
+		filter.Topic = retrievalCtx.Topics[0] // Use first topic
+	}
+
+	// Perform vector search
+	searchResult, err := r.experienceStore.Search(ctx, userID, queryVec, filter)
+	if err != nil {
+		slog.Warn("failed to search experiences", "user_id", userID, "err", err)
+		return results, domain.LayerRetrievalStats{
+			Layer:          domain.RetrievalLayerExperience,
+			CandidatesFound: 0,
+			Error:          err.Error(),
+			LatencyMs:      time.Since(startTime).Milliseconds(),
+		}
+	}
+
+	// Score each experience
+	for _, exp := range searchResult.Experiences {
+		// Get semantic score from vector search result
+		semanticScore := 0.5
+		if exp.Score != nil {
+			semanticScore = *exp.Score
+		}
+
+		// Calculate time decay score
+		timeDecayScore := r.calculateTimeDecayScore(exp.CreatedAt, timeDecayRate)
+
+		// Calculate importance score (use confidence from metadata)
+		importanceScore := exp.Metadata.Confidence
+		if importanceScore <= 0 {
+			importanceScore = 0.5
+		}
+
+		// Calculate final score
+		finalScore := weights.W1ExactMatch*0.0 + // No exact match for experiences
+			weights.W2Semantic*semanticScore +
+			weights.W3TimeDecay*timeDecayScore +
+			weights.W4Importance*importanceScore
+
+		result := domain.HybridRetrieverResult{
+			ID:          exp.ExperienceID,
+			Content:     exp.Content,
+			SourceLayer: domain.RetrievalLayerExperience,
+			SourceType:  "experience",
+			ScoreBreakdown: domain.ScoreBreakdown{
+				ExactMatchScore: 0.0,
+				SemanticScore:   semanticScore,
+				TimeDecayScore:  timeDecayScore,
+				ImportanceScore: importanceScore,
+				Weights:         weights,
+			},
+			FinalScore: finalScore,
+			TokenCount: r.tokenizer.CountTokens(exp.Content),
+			CreatedAt:  exp.CreatedAt,
+			Metadata: map[string]interface{}{
+				"topic":      exp.Metadata.Topic,
+				"outcome":    string(exp.Metadata.Outcome),
+				"confidence": exp.Metadata.Confidence,
+				"tags":       exp.Metadata.Tags,
+				"session_id": exp.Metadata.SessionID,
+			},
+		}
+		results = append(results, result)
+	}
+
+	latency := time.Since(startTime).Milliseconds()
+	slog.Debug("experience retrieval completed",
+		"user_id", userID,
+		"candidates", len(results),
+		"latency_ms", latency,
+	)
+
+	return results, domain.LayerRetrievalStats{
+		Layer:            domain.RetrievalLayerExperience,
+		CandidatesFound:  len(searchResult.Experiences),
+		CandidatesReturned: len(results),
+		AvgScore:         r.calculateAverageScore(results),
+		LatencyMs:        latency,
+	}
+}
+
+// detectQueryIntent determines the intent of the query.
+func (r *HybridRetriever) detectQueryIntent(query string) string {
+	queryLower := strings.ToLower(query)
+
+	// Check for exact fact queries (e.g., "What is my name?", "My preferences")
+	exactPatterns := []string{
+		"what is my", "what's my", "what are my",
+		"my name", "my email", "my phone", "my address",
+		"my preference", "my goal", "my skill",
+		"i am", "i'm", "i work", "i live",
+		"我叫", "我的名字", "我的邮箱", "我的电话",
+		"我的偏好", "我的目标", "我的技能",
+	}
+
+	for _, pattern := range exactPatterns {
+		if strings.Contains(queryLower, pattern) {
+			return "exact_fact"
+		}
+	}
+
+	// Check for semantic/experience queries
+	semanticPatterns := []string{
+		"discussed", "talked about", "mentioned", "we discussed",
+		"before", "previous", "earlier", "last time",
+		"solution", "approach", "tried", "attempted",
+		"讨论过", "之前", "上次", "解决方案",
+	}
+
+	for _, pattern := range semanticPatterns {
+		if strings.Contains(queryLower, pattern) {
+			return "semantic"
+		}
+	}
+
+	return "hybrid"
+}
+
+// extractKeywords extracts keywords from the query.
+func (r *HybridRetriever) extractKeywords(query string) []string {
+	// Simple keyword extraction
+	// Remove common stop words
+	stopWords := map[string]bool{
+		"what": true, "is": true, "my": true, "the": true, "a": true, "an": true,
+		"i": true, "you": true, "we": true, "they": true, "it": true,
+		"do": true, "did": true, "does": true, "can": true, "could": true,
+		"would": true, "should": true, "will": true, "have": true, "has": true,
+		"about": true, "for": true, "with": true, "from": true, "to": true,
+		"的": true, "是": true, "在": true, "了": true, "和": true,
+		"我": true, "你": true, "他": true, "她": true, "它": true,
+	}
+
+	words := strings.Fields(strings.ToLower(query))
+	var keywords []string
+	for _, word := range words {
+		word = strings.Trim(word, ".,!?;:\"'()[]{}")
+		if len(word) >= 2 && !stopWords[word] {
+			keywords = append(keywords, word)
+		}
+	}
+
+	return keywords
+}
+
+// detectCategories detects fact categories from the query.
+func (r *HybridRetriever) detectCategories(query string) []domain.FactCategory {
+	queryLower := strings.ToLower(query)
+	var categories []domain.FactCategory
+
+	// Check for personal category patterns
+	personalPatterns := []string{"name", "email", "phone", "address", "age", "birthday", "location", "名字", "邮箱", "电话", "地址", "年龄", "生日", "位置"}
+	for _, pattern := range personalPatterns {
+		if strings.Contains(queryLower, pattern) {
+			categories = append(categories, domain.CategoryPersonal)
+			break
+		}
+	}
+
+	// Check for preference category patterns
+	preferencePatterns := []string{"prefer", "like", "favorite", "want", "偏好", "喜欢", "最爱", "想要"}
+	for _, pattern := range preferencePatterns {
+		if strings.Contains(queryLower, pattern) {
+			categories = append(categories, domain.CategoryPreference)
+			break
+		}
+	}
+
+	// Check for goal category patterns
+	goalPatterns := []string{"goal", "objective", "target", "aim", "plan", "目标", "计划", "目的"}
+	for _, pattern := range goalPatterns {
+		if strings.Contains(queryLower, pattern) {
+			categories = append(categories, domain.CategoryGoal)
+			break
+		}
+	}
+
+	// Check for skill category patterns
+	skillPatterns := []string{"skill", "ability", "expertise", "know", "can do", "技能", "能力", "专长", "会"}
+	for _, pattern := range skillPatterns {
+		if strings.Contains(queryLower, pattern) {
+			categories = append(categories, domain.CategorySkill)
+			break
+		}
+	}
+
+	// If no categories detected, include all
+	if len(categories) == 0 {
+		categories = []domain.FactCategory{
+			domain.CategoryPersonal,
+			domain.CategoryPreference,
+			domain.CategoryGoal,
+			domain.CategorySkill,
+		}
+	}
+
+	return categories
+}
+
+// calculateExactMatchScore calculates the exact match score for a user profile fact.
+func (r *HybridRetriever) calculateExactMatchScore(queryLower string, key, value string, category domain.FactCategory) float64 {
+	keyLower := strings.ToLower(key)
+	valueLower := strings.ToLower(value)
+	categoryLower := strings.ToLower(string(category))
+
+	// Direct match on key (highest score)
+	if strings.Contains(queryLower, keyLower) || strings.Contains(keyLower, queryLower) {
+		return 1.0
+	}
+
+	// Match on value
+	if strings.Contains(queryLower, valueLower) {
+		return 0.8
+	}
+
+	// Match on category keywords
+	if strings.Contains(queryLower, categoryLower) {
+		return 0.7
+	}
+
+	// Check if any word in query matches key
+	queryWords := strings.Fields(queryLower)
+	for _, word := range queryWords {
+		if len(word) >= 3 && strings.Contains(keyLower, word) {
+			return 0.6
+		}
+	}
+
+	return 0.0
+}
+
+// calculateKeywordMatchScore calculates the keyword match score for a conversation summary.
+func (r *HybridRetriever) calculateKeywordMatchScore(queryLower string, keywords []string, summary domain.ConversationSummary) float64 {
+	// Combine all summary text
+	summaryText := strings.ToLower(strings.Join([]string{
+		summary.Title, summary.Summary, summary.UserIntent,
+		strings.Join(summary.KeyTopics, " "),
+	}, " "))
+
+	// Count keyword matches
+	matchCount := 0
+	for _, keyword := range keywords {
+		if strings.Contains(summaryText, keyword) {
+			matchCount++
+		}
+	}
+
+	// Calculate score based on match ratio
+	if len(keywords) == 0 {
+		return 0.0
+	}
+
+	score := float64(matchCount) / float64(len(keywords))
+
+	// Boost for title match
+	if strings.Contains(strings.ToLower(summary.Title), queryLower) {
+		score += 0.3
+	}
+
+	// Cap at 1.0
+	if score > 1.0 {
+		score = 1.0
+	}
+
+	return score
+}
+
+// calculateTimeDecayScore calculates the time decay score based on age.
+func (r *HybridRetriever) calculateTimeDecayScore(createdAt time.Time, decayRate float64) float64 {
+	hoursSinceCreation := time.Since(createdAt).Hours()
+	score := 1.0 / (1.0 + decayRate*hoursSinceCreation)
+
+	// Ensure score is between 0 and 1
+	if score > 1.0 {
+		score = 1.0
+	}
+	if score < 0.0 {
+		score = 0.0
+	}
+
+	return score
+}
+
+// deduplicateResults removes duplicate results based on content similarity.
+func (r *HybridRetriever) deduplicateResults(results []domain.HybridRetrieverResult) []domain.HybridRetrieverResult {
+	if len(results) <= 1 {
+		return results
+	}
+
+	// Use a map to track seen content hashes
+	seen := make(map[string]bool)
+	var deduped []domain.HybridRetrieverResult
+
+	for _, result := range results {
+		// Create a simple hash based on content
+		hash := r.contentHash(result.Content)
+		if !seen[hash] {
+			seen[hash] = true
+			deduped = append(deduped, result)
+		}
+	}
+
+	return deduped
+}
+
+// contentHash creates a simple hash of content for deduplication.
+func (r *HybridRetriever) contentHash(content string) string {
+	// Normalize content: lowercase, remove extra spaces
+	normalized := strings.ToLower(strings.TrimSpace(content))
+	normalized = strings.Join(strings.Fields(normalized), " ")
+
+	// For deduplication, use first 100 chars as a simple hash
+	if len(normalized) > 100 {
+		normalized = normalized[:100]
+	}
+
+	return normalized
+}
+
+// sortResultsByScore sorts results by final score in descending order.
+func (r *HybridRetriever) sortResultsByScore(results []domain.HybridRetrieverResult) {
+	// Use simple insertion sort for small arrays
+	for i := 1; i < len(results); i++ {
+		for j := i; j > 0 && results[j].FinalScore > results[j-1].FinalScore; j-- {
+			results[j], results[j-1] = results[j-1], results[j]
+		}
+	}
+}
+
+// calculateTotalTokens calculates the total token count of all results.
+func (r *HybridRetriever) calculateTotalTokens(results []domain.HybridRetrieverResult) int {
+	total := 0
+	for _, result := range results {
+		total += result.TokenCount
+	}
+	return total
+}
+
+// trimToTokenBudget trims results to fit within the token budget.
+// Keeps highest-scoring results first.
+func (r *HybridRetriever) trimToTokenBudget(results []domain.HybridRetrieverResult, maxTokens int) []domain.HybridRetrieverResult {
+	if len(results) == 0 {
+		return results
+	}
+
+	var trimmed []domain.HybridRetrieverResult
+	totalTokens := 0
+
+	for _, result := range results {
+		if totalTokens+result.TokenCount <= maxTokens {
+			trimmed = append(trimmed, result)
+			totalTokens += result.TokenCount
+		}
+	}
+
+	return trimmed
+}
+
+// calculateAverageScore calculates the average final score of results.
+func (r *HybridRetriever) calculateAverageScore(results []domain.HybridRetrieverResult) float64 {
+	if len(results) == 0 {
+		return 0.0
+	}
+
+	total := 0.0
+	for _, result := range results {
+		total += result.FinalScore
+	}
+
+	return total / float64(len(results))
+}
+
+// WithTokenizer sets a custom tokenizer for the retriever.
+func (r *HybridRetriever) WithTokenizer(t tokenizer.Tokenizer) *HybridRetriever {
+	r.tokenizer = t
+	return r
+}
+
+// GetConfig returns the current configuration.
+func (r *HybridRetriever) GetConfig() domain.HybridRetrieverConfig {
+	return r.config
+}

--- a/server/internal/service/hybrid_retriever_test.go
+++ b/server/internal/service/hybrid_retriever_test.go
@@ -1,0 +1,715 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/devioslang/memorix/server/internal/domain"
+	"github.com/devioslang/memorix/server/internal/vectorstore"
+)
+
+// MockUserProfileRepo implements repository.UserProfileFactRepo for testing.
+type MockUserProfileRepo struct {
+	Facts []domain.UserProfileFact
+}
+
+func (m *MockUserProfileRepo) Create(ctx context.Context, fact *domain.UserProfileFact) error {
+	m.Facts = append(m.Facts, *fact)
+	return nil
+}
+
+func (m *MockUserProfileRepo) GetByID(ctx context.Context, factID string) (*domain.UserProfileFact, error) {
+	for _, f := range m.Facts {
+		if f.FactID == factID {
+			return &f, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+
+func (m *MockUserProfileRepo) GetByUserID(ctx context.Context, userID string) ([]domain.UserProfileFact, error) {
+	var result []domain.UserProfileFact
+	for _, f := range m.Facts {
+		if f.UserID == userID {
+			result = append(result, f)
+		}
+	}
+	return result, nil
+}
+
+func (m *MockUserProfileRepo) GetByUserIDAndCategory(ctx context.Context, userID string, category domain.FactCategory) ([]domain.UserProfileFact, error) {
+	var result []domain.UserProfileFact
+	for _, f := range m.Facts {
+		if f.UserID == userID && f.Category == category {
+			result = append(result, f)
+		}
+	}
+	return result, nil
+}
+
+func (m *MockUserProfileRepo) List(ctx context.Context, f domain.UserProfileFactFilter) (facts []domain.UserProfileFact, total int, err error) {
+	return m.Facts, len(m.Facts), nil
+}
+
+func (m *MockUserProfileRepo) Update(ctx context.Context, fact *domain.UserProfileFact) error {
+	for i, f := range m.Facts {
+		if f.FactID == fact.FactID {
+			m.Facts[i] = *fact
+			return nil
+		}
+	}
+	return domain.ErrNotFound
+}
+
+func (m *MockUserProfileRepo) Delete(ctx context.Context, factID string) error {
+	for i, f := range m.Facts {
+		if f.FactID == factID {
+			m.Facts = append(m.Facts[:i], m.Facts[i+1:]...)
+			return nil
+		}
+	}
+	return domain.ErrNotFound
+}
+
+func (m *MockUserProfileRepo) DeleteByUserID(ctx context.Context, userID string) error {
+	var filtered []domain.UserProfileFact
+	for _, f := range m.Facts {
+		if f.UserID != userID {
+			filtered = append(filtered, f)
+		}
+	}
+	m.Facts = filtered
+	return nil
+}
+
+func (m *MockUserProfileRepo) CountByUserID(ctx context.Context, userID string) (int, error) {
+	count := 0
+	for _, f := range m.Facts {
+		if f.UserID == userID {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (m *MockUserProfileRepo) DeleteOldestLowConfidence(ctx context.Context, userID string, count int) (int64, error) {
+	return 0, nil
+}
+
+func (m *MockUserProfileRepo) TouchLastAccessed(ctx context.Context, factID string) error {
+	return nil
+}
+
+func (m *MockUserProfileRepo) GetByKey(ctx context.Context, userID string, category domain.FactCategory, key string) (*domain.UserProfileFact, error) {
+	for _, f := range m.Facts {
+		if f.UserID == userID && f.Category == category && f.Key == key {
+			return &f, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+
+func (m *MockUserProfileRepo) SearchByValue(ctx context.Context, userID string, value string, limit int) ([]domain.UserProfileFact, error) {
+	return nil, nil
+}
+
+// MockSummaryRepo implements repository.ConversationSummaryRepo for testing.
+type MockSummaryRepo struct {
+	Summaries []domain.ConversationSummary
+}
+
+func (m *MockSummaryRepo) Create(ctx context.Context, summary *domain.ConversationSummary) error {
+	m.Summaries = append(m.Summaries, *summary)
+	return nil
+}
+
+func (m *MockSummaryRepo) GetByID(ctx context.Context, summaryID string) (*domain.ConversationSummary, error) {
+	for _, s := range m.Summaries {
+		if s.SummaryID == summaryID {
+			return &s, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+
+func (m *MockSummaryRepo) GetByUserID(ctx context.Context, userID string, limit int) ([]domain.ConversationSummary, error) {
+	var result []domain.ConversationSummary
+	for _, s := range m.Summaries {
+		if s.UserID == userID {
+			result = append(result, s)
+		}
+	}
+	if len(result) > limit {
+		result = result[:limit]
+	}
+	return result, nil
+}
+
+func (m *MockSummaryRepo) GetBySessionID(ctx context.Context, sessionID string) (*domain.ConversationSummary, error) {
+	for _, s := range m.Summaries {
+		if s.SessionID == sessionID {
+			return &s, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+
+func (m *MockSummaryRepo) List(ctx context.Context, f domain.ConversationSummaryFilter) (summaries []domain.ConversationSummary, total int, err error) {
+	return m.Summaries, len(m.Summaries), nil
+}
+
+func (m *MockSummaryRepo) Delete(ctx context.Context, summaryID string) error {
+	for i, s := range m.Summaries {
+		if s.SummaryID == summaryID {
+			m.Summaries = append(m.Summaries[:i], m.Summaries[i+1:]...)
+			return nil
+		}
+	}
+	return domain.ErrNotFound
+}
+
+func (m *MockSummaryRepo) DeleteOldest(ctx context.Context, userID string, count int) (int64, error) {
+	return 0, nil
+}
+
+func (m *MockSummaryRepo) CountByUserID(ctx context.Context, userID string) (int, error) {
+	count := 0
+	for _, s := range m.Summaries {
+		if s.UserID == userID {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// MockExperienceStore implements vectorstore.VectorStore for testing.
+type MockExperienceStore struct {
+	Experiences []domain.Experience
+}
+
+func (m *MockExperienceStore) Write(ctx context.Context, exp *domain.Experience) error {
+	m.Experiences = append(m.Experiences, *exp)
+	return nil
+}
+
+func (m *MockExperienceStore) WriteBatch(ctx context.Context, experiences []*domain.Experience) (int, error) {
+	for _, exp := range experiences {
+		m.Experiences = append(m.Experiences, *exp)
+	}
+	return len(experiences), nil
+}
+
+func (m *MockExperienceStore) Search(ctx context.Context, userID string, queryVec []float32, filter domain.ExperienceFilter) (*domain.ExperienceSearchResult, error) {
+	var result []domain.Experience
+	for _, exp := range m.Experiences {
+		if exp.UserID == userID {
+			score := 0.8 // Mock score
+			exp.Score = &score
+			result = append(result, exp)
+		}
+	}
+	if len(result) > filter.Limit {
+		result = result[:filter.Limit]
+	}
+	return &domain.ExperienceSearchResult{
+		Experiences: result,
+		Total:       len(result),
+		Query:       filter.Query,
+		LatencyMs:   10,
+	}, nil
+}
+
+func (m *MockExperienceStore) GetByID(ctx context.Context, userID, experienceID string) (*domain.Experience, error) {
+	for _, exp := range m.Experiences {
+		if exp.UserID == userID && exp.ExperienceID == experienceID {
+			return &exp, nil
+		}
+	}
+	return nil, vectorstore.ErrNotFound
+}
+
+func (m *MockExperienceStore) Delete(ctx context.Context, userID, experienceID string) error {
+	for i, exp := range m.Experiences {
+		if exp.UserID == userID && exp.ExperienceID == experienceID {
+			m.Experiences = append(m.Experiences[:i], m.Experiences[i+1:]...)
+			return nil
+		}
+	}
+	return vectorstore.ErrNotFound
+}
+
+func (m *MockExperienceStore) DeleteByUser(ctx context.Context, userID string) error {
+	var filtered []domain.Experience
+	for _, exp := range m.Experiences {
+		if exp.UserID != userID {
+			filtered = append(filtered, exp)
+		}
+	}
+	m.Experiences = filtered
+	return nil
+}
+
+func (m *MockExperienceStore) Stats(ctx context.Context, userID string) (*domain.ExperienceStats, error) {
+	return &domain.ExperienceStats{UserID: userID, TotalExperiences: len(m.Experiences)}, nil
+}
+
+func (m *MockExperienceStore) Health(ctx context.Context) error {
+	return nil
+}
+
+func (m *MockExperienceStore) Close() error {
+	return nil
+}
+
+// TestHybridRetriever_ExactFactQuery tests exact fact queries like "What's my name?"
+func TestHybridRetriever_ExactFactQuery(t *testing.T) {
+	// Setup mocks
+	profileRepo := &MockUserProfileRepo{
+		Facts: []domain.UserProfileFact{
+			{
+				FactID:     "fact-1",
+				UserID:     "user-1",
+				Category:   domain.CategoryPersonal,
+				Key:        "name",
+				Value:      "Alice",
+				Source:     domain.SourceExplicit,
+				Confidence: 1.0,
+				CreatedAt:  time.Now(),
+			},
+		},
+	}
+
+	summaryRepo := &MockSummaryRepo{}
+	expStore := &MockExperienceStore{}
+	embedder := NewMockEmbedder(1536)
+
+	config := domain.DefaultHybridRetrieverConfig()
+	retriever := NewHybridRetriever(profileRepo, summaryRepo, expStore, embedder, config)
+
+	// Test exact fact query
+	result, err := retriever.Retrieve(context.Background(), "user-1", "What's my name?", nil)
+	if err != nil {
+		t.Fatalf("Retrieve failed: %v", err)
+	}
+
+	// Verify results
+	if len(result.Results) == 0 {
+		t.Fatal("Expected at least one result for exact fact query")
+	}
+
+	// First result should be from user profile
+	if result.Results[0].SourceLayer != domain.RetrievalLayerUserProfile {
+		t.Errorf("Expected first result from user_profile layer, got %s", result.Results[0].SourceLayer)
+	}
+
+	// Verify score breakdown has exact match score
+	if result.Results[0].ScoreBreakdown.ExactMatchScore < 0.5 {
+		t.Errorf("Expected high exact match score, got %f", result.Results[0].ScoreBreakdown.ExactMatchScore)
+	}
+
+	// Verify tracing
+	if result.RetrievalTrace.QueryIntent != "exact_fact" {
+		t.Errorf("Expected query intent 'exact_fact', got %s", result.RetrievalTrace.QueryIntent)
+	}
+
+	t.Logf("Exact fact query test passed: %d results, intent=%s", len(result.Results), result.RetrievalTrace.QueryIntent)
+}
+
+// TestHybridRetriever_SemanticQuery tests semantic queries like "discussed architecture"
+func TestHybridRetriever_SemanticQuery(t *testing.T) {
+	// Setup mocks
+	profileRepo := &MockUserProfileRepo{}
+
+	summaryRepo := &MockSummaryRepo{
+		Summaries: []domain.ConversationSummary{
+			{
+				SummaryID:  "summary-1",
+				UserID:     "user-1",
+				SessionID:  "session-1",
+				Title:      "Architecture discussion",
+				Summary:    "We discussed microservices architecture patterns and best practices",
+				KeyTopics:  []string{"architecture", "microservices", "patterns"},
+				UserIntent: "Learn about architecture patterns",
+				CreatedAt:  time.Now().Add(-24 * time.Hour),
+			},
+		},
+	}
+
+	expStore := &MockExperienceStore{
+		Experiences: []domain.Experience{
+			{
+				ExperienceID: "exp-1",
+				UserID:       "user-1",
+				Content:      "Discussed microservices architecture and decided on event-driven approach",
+				Metadata: domain.ExperienceMetadata{
+					Topic:       "architecture",
+					Outcome:     domain.OutcomeSuccess,
+					Confidence:  0.9,
+					SessionID:   "session-1",
+				},
+				CreatedAt: time.Now().Add(-48 * time.Hour),
+			},
+		},
+	}
+
+	embedder := NewMockEmbedder(1536)
+	config := domain.DefaultHybridRetrieverConfig()
+	retriever := NewHybridRetriever(profileRepo, summaryRepo, expStore, embedder, config)
+
+	// Test semantic query
+	result, err := retriever.Retrieve(context.Background(), "user-1", "What architecture patterns did we discuss before?", nil)
+	if err != nil {
+		t.Fatalf("Retrieve failed: %v", err)
+	}
+
+	// Verify results
+	if len(result.Results) == 0 {
+		t.Fatal("Expected at least one result for semantic query")
+	}
+
+	// Verify tracing
+	if result.RetrievalTrace.QueryIntent != "semantic" {
+		t.Errorf("Expected query intent 'semantic', got %s", result.RetrievalTrace.QueryIntent)
+	}
+
+	t.Logf("Semantic query test passed: %d results, intent=%s", len(result.Results), result.RetrievalTrace.QueryIntent)
+}
+
+// TestHybridRetriever_TokenBudget tests token budget enforcement
+func TestHybridRetriever_TokenBudget(t *testing.T) {
+	// Setup mocks with many results
+	profileRepo := &MockUserProfileRepo{}
+	summaryRepo := &MockSummaryRepo{}
+
+	// Create many experiences to exceed token budget
+	var experiences []domain.Experience
+	for i := 0; i < 20; i++ {
+		content := "This is a long experience entry about microservices and distributed systems architecture with many details that should increase token count significantly."
+		experiences = append(experiences, domain.Experience{
+			ExperienceID: string(rune('a' + i)),
+			UserID:       "user-1",
+			Content:      content,
+			Metadata: domain.ExperienceMetadata{
+				Topic:      "architecture",
+				Confidence: 0.8,
+			},
+			CreatedAt: time.Now().Add(-time.Duration(i) * time.Hour),
+		})
+	}
+	expStore := &MockExperienceStore{Experiences: experiences}
+	embedder := NewMockEmbedder(1536)
+	config := domain.DefaultHybridRetrieverConfig()
+	retriever := NewHybridRetriever(profileRepo, summaryRepo, expStore, embedder, config)
+
+	// Set a low token budget
+	ctx := &domain.HybridRetrievalContext{
+		MaxTokens: 500,
+	}
+
+	result, err := retriever.Retrieve(context.Background(), "user-1", "architecture patterns", ctx)
+	if err != nil {
+		t.Fatalf("Retrieve failed: %v", err)
+	}
+
+	// Verify token budget is respected
+	if result.TotalTokens > ctx.MaxTokens {
+		t.Errorf("Token budget exceeded: %d > %d", result.TotalTokens, ctx.MaxTokens)
+	}
+
+	// Verify truncation flag
+	if !result.Truncated {
+		t.Error("Expected truncated=true when budget was applied")
+	}
+
+	t.Logf("Token budget test passed: %d tokens (budget: %d), truncated=%v", result.TotalTokens, ctx.MaxTokens, result.Truncated)
+}
+
+// TestHybridRetriever_Deduplication tests result deduplication
+func TestHybridRetriever_Deduplication(t *testing.T) {
+	// Setup mocks with duplicate content
+	profileRepo := &MockUserProfileRepo{}
+
+	now := time.Now()
+	summaryRepo := &MockSummaryRepo{
+		Summaries: []domain.ConversationSummary{
+			{
+				SummaryID:  "summary-1",
+				UserID:     "user-1",
+				Title:      "Same topic",
+				Summary:    "Duplicate content about microservices",
+				KeyTopics:  []string{"microservices"},
+				CreatedAt:  now,
+			},
+			{
+				SummaryID:  "summary-2",
+				UserID:     "user-1",
+				Title:      "Same topic",
+				Summary:    "Duplicate content about microservices",
+				KeyTopics:  []string{"microservices"},
+				CreatedAt:  now,
+			},
+		},
+	}
+
+	expStore := &MockExperienceStore{}
+	embedder := NewMockEmbedder(1536)
+	config := domain.DefaultHybridRetrieverConfig()
+	retriever := NewHybridRetriever(profileRepo, summaryRepo, expStore, embedder, config)
+
+	result, err := retriever.Retrieve(context.Background(), "user-1", "microservices", nil)
+	if err != nil {
+		t.Fatalf("Retrieve failed: %v", err)
+	}
+
+	// Verify deduplication happened
+	if result.RetrievalTrace.DeduplicationStats.DuplicatesRemoved > 0 {
+		t.Logf("Deduplication removed %d duplicates", result.RetrievalTrace.DeduplicationStats.DuplicatesRemoved)
+	}
+
+	t.Logf("Deduplication test passed: total_candidates=%d, final=%d",
+		result.RetrievalTrace.DeduplicationStats.TotalCandidates, len(result.Results))
+}
+
+// TestHybridRetriever_ScoringWeights tests custom scoring weights
+func TestHybridRetriever_ScoringWeights(t *testing.T) {
+	profileRepo := &MockUserProfileRepo{
+		Facts: []domain.UserProfileFact{
+			{
+				FactID:     "fact-1",
+				UserID:     "user-1",
+				Category:   domain.CategoryPersonal,
+				Key:        "name",
+				Value:      "Bob",
+				Confidence: 1.0,
+				CreatedAt:  time.Now(),
+			},
+		},
+	}
+
+	summaryRepo := &MockSummaryRepo{}
+	expStore := &MockExperienceStore{}
+	embedder := NewMockEmbedder(1536)
+
+	// Custom weights prioritizing exact match
+	config := domain.DefaultHybridRetrieverConfig()
+	config.DefaultWeights = domain.ScoringWeights{
+		W1ExactMatch: 0.7,
+		W2Semantic:   0.1,
+		W3TimeDecay:  0.1,
+		W4Importance: 0.1,
+	}
+	retriever := NewHybridRetriever(profileRepo, summaryRepo, expStore, embedder, config)
+
+	result, err := retriever.Retrieve(context.Background(), "user-1", "What's my name?", nil)
+	if err != nil {
+		t.Fatalf("Retrieve failed: %v", err)
+	}
+
+	// Verify weights were applied
+	if len(result.Results) > 0 {
+		weights := result.Results[0].ScoreBreakdown.Weights
+		if weights.W1ExactMatch != 0.7 {
+			t.Errorf("Expected W1ExactMatch=0.7, got %f", weights.W1ExactMatch)
+		}
+		t.Logf("Scoring weights test passed: W1=%f, W2=%f, W3=%f, W4=%f",
+			weights.W1ExactMatch, weights.W2Semantic, weights.W3TimeDecay, weights.W4Importance)
+	}
+}
+
+// TestHybridRetriever_LayerFiltering tests filtering by layer
+func TestHybridRetriever_LayerFiltering(t *testing.T) {
+	profileRepo := &MockUserProfileRepo{
+		Facts: []domain.UserProfileFact{
+			{
+				FactID:     "fact-1",
+				UserID:     "user-1",
+				Category:   domain.CategoryPersonal,
+				Key:        "name",
+				Value:      "Charlie",
+				Confidence: 1.0,
+				CreatedAt:  time.Now(),
+			},
+		},
+	}
+
+	summaryRepo := &MockSummaryRepo{
+		Summaries: []domain.ConversationSummary{
+			{
+				SummaryID:  "summary-1",
+				UserID:     "user-1",
+				Title:      "Test summary",
+				Summary:    "Test content",
+				CreatedAt:  time.Now(),
+			},
+		},
+	}
+
+	expStore := &MockExperienceStore{}
+	embedder := NewMockEmbedder(1536)
+	config := domain.DefaultHybridRetrieverConfig()
+	retriever := NewHybridRetriever(profileRepo, summaryRepo, expStore, embedder, config)
+
+	// Only search user profile layer
+	ctx := &domain.HybridRetrievalContext{
+		IncludeLayers: []domain.RetrievalSourceLayer{domain.RetrievalLayerUserProfile},
+	}
+
+	result, err := retriever.Retrieve(context.Background(), "user-1", "name", ctx)
+	if err != nil {
+		t.Fatalf("Retrieve failed: %v", err)
+	}
+
+	// Verify only user profile layer was searched
+	for _, res := range result.Results {
+		if res.SourceLayer != domain.RetrievalLayerUserProfile {
+			t.Errorf("Expected only user_profile results, got %s", res.SourceLayer)
+		}
+	}
+
+	// Verify layer statistics only include user profile
+	for _, stat := range result.LayerStatistics {
+		if stat.Layer != domain.RetrievalLayerUserProfile {
+			t.Errorf("Expected only user_profile layer stats, got %s", stat.Layer)
+		}
+	}
+
+	t.Logf("Layer filtering test passed: %d results from user_profile only", len(result.Results))
+}
+
+// TestHybridRetriever_ComprehensiveTracing tests complete tracing information
+func TestHybridRetriever_ComprehensiveTracing(t *testing.T) {
+	profileRepo := &MockUserProfileRepo{
+		Facts: []domain.UserProfileFact{
+			{
+				FactID:     "fact-1",
+				UserID:     "user-1",
+				Category:   domain.CategoryPersonal,
+				Key:        "name",
+				Value:      "David",
+				Confidence: 1.0,
+				CreatedAt:  time.Now(),
+			},
+		},
+	}
+
+	summaryRepo := &MockSummaryRepo{
+		Summaries: []domain.ConversationSummary{
+			{
+				SummaryID:  "summary-1",
+				UserID:     "user-1",
+				Title:      "Test",
+				Summary:    "Test summary",
+				CreatedAt:  time.Now(),
+			},
+		},
+	}
+
+	expStore := &MockExperienceStore{}
+	embedder := NewMockEmbedder(1536)
+	config := domain.DefaultHybridRetrieverConfig()
+	retriever := NewHybridRetriever(profileRepo, summaryRepo, expStore, embedder, config)
+
+	result, err := retriever.Retrieve(context.Background(), "user-1", "What's my name?", nil)
+	if err != nil {
+		t.Fatalf("Retrieve failed: %v", err)
+	}
+
+	// Verify comprehensive tracing
+	trace := result.RetrievalTrace
+	if trace.QueryIntent == "" {
+		t.Error("Missing query intent in trace")
+	}
+	if len(trace.ExtractedKeywords) == 0 {
+		t.Error("Missing extracted keywords in trace")
+	}
+	if trace.DeduplicationStats.TotalCandidates == 0 {
+		t.Error("Missing deduplication stats in trace")
+	}
+
+	// Verify layer statistics
+	if len(result.LayerStatistics) == 0 {
+		t.Error("Missing layer statistics")
+	}
+
+	for _, stat := range result.LayerStatistics {
+		if stat.Layer == "" {
+			t.Error("Missing layer name in statistics")
+		}
+		if stat.LatencyMs == 0 {
+			t.Logf("Warning: zero latency for layer %s", stat.Layer)
+		}
+	}
+
+	// Verify score breakdown for each result
+	for _, res := range result.Results {
+		sb := res.ScoreBreakdown
+		if sb.Weights.W1ExactMatch+sb.Weights.W2Semantic+sb.Weights.W3TimeDecay+sb.Weights.W4Importance == 0 {
+			t.Error("Missing scoring weights in result")
+		}
+		if res.FinalScore <= 0 {
+			t.Error("Expected positive final score")
+		}
+	}
+
+	t.Logf("Comprehensive tracing test passed: intent=%s, keywords=%v, layers=%d",
+		trace.QueryIntent, trace.ExtractedKeywords, len(result.LayerStatistics))
+}
+
+// TestHybridRetriever_TimeDecay tests time decay scoring
+func TestHybridRetriever_TimeDecay(t *testing.T) {
+	profileRepo := &MockUserProfileRepo{
+		Facts: []domain.UserProfileFact{
+			{
+				FactID:     "fact-old",
+				UserID:     "user-1",
+				Category:   domain.CategoryPersonal,
+				Key:        "old_fact",
+				Value:      "Old value",
+				Confidence: 1.0,
+				CreatedAt:  time.Now().Add(-30 * 24 * time.Hour), // 30 days ago
+			},
+			{
+				FactID:     "fact-new",
+				UserID:     "user-1",
+				Category:   domain.CategoryPersonal,
+				Key:        "new_fact",
+				Value:      "New value",
+				Confidence: 1.0,
+				CreatedAt:  time.Now(), // Now
+			},
+		},
+	}
+
+	summaryRepo := &MockSummaryRepo{}
+	expStore := &MockExperienceStore{}
+	embedder := NewMockEmbedder(1536)
+	config := domain.DefaultHybridRetrieverConfig()
+	retriever := NewHybridRetriever(profileRepo, summaryRepo, expStore, embedder, config)
+
+	result, err := retriever.Retrieve(context.Background(), "user-1", "fact", nil)
+	if err != nil {
+		t.Fatalf("Retrieve failed: %v", err)
+	}
+
+	// Find the two facts in results
+	var oldFact, newFact *domain.HybridRetrieverResult
+	for _, res := range result.Results {
+		if res.ID == "fact-old" {
+			oldFact = &res
+		}
+		if res.ID == "fact-new" {
+			newFact = &res
+		}
+	}
+
+	if oldFact != nil && newFact != nil {
+		// New fact should have higher time decay score
+		if newFact.ScoreBreakdown.TimeDecayScore <= oldFact.ScoreBreakdown.TimeDecayScore {
+			t.Errorf("Expected newer fact to have higher time decay score: new=%f, old=%f",
+				newFact.ScoreBreakdown.TimeDecayScore, oldFact.ScoreBreakdown.TimeDecayScore)
+		}
+		t.Logf("Time decay test passed: new=%f, old=%f",
+			newFact.ScoreBreakdown.TimeDecayScore, oldFact.ScoreBreakdown.TimeDecayScore)
+	}
+}


### PR DESCRIPTION
Closes #10

## Summary
实现混合检索编排器，统一编排结构化查询和向量检索。

## Retrieval Strategy (Cascade)

| 优先级 | 层级 | 检索方式 | 用途 |
|--------|------|----------|------|
| 1 | User Profile Store | 精确匹配 key/category | 事实查询 ("我叫什么") |
| 2 | Conversation Summary | 关键词 + 时间范围 | 近期上下文 |
| 3 | Vector Store | 语义相似度 | 相关经验 |

## Scoring Formula
\`\`\`
FinalScore = w1*ExactMatch + w2*Semantic + w3*TimeDecay + w4*Importance
Default: 0.4 + 0.3 + 0.15 + 0.15 = 1.0
\`\`\`

## Features

- **Deduplication**: 跨层级去重
- **Token Budget**: 结果裁剪到预算内
- **Query Intent**: 自动检测查询意图 (exact_fact / semantic / hybrid)
- **Tracing**: 完整的检索追踪日志
- **Configurable**: 可配置权重、衰减率、top-K 等

## Acceptance Criteria

- [x] 精确事实问题优先命中 Profile Store
- [x] 模糊问题能从向量库召回相关经验
- [x] 综合结果 Token 数在预算内
- [x] 完整 tracing 日志可追溯

## Files Changed

- \`server/internal/domain/hybrid_retriever.go\` - 数据模型 + 配置
- \`server/internal/service/hybrid_retriever.go\` - 核心实现 (851行)
- \`server/internal/service/hybrid_retriever_test.go\` - 单元测试 (715行)